### PR TITLE
🧪 Test server-side GameEngine.calculateTrickPoints scoring

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "start": "ts-node src/index.ts",
-    "build": "tsc"
+    "build": "tsc",
+    "test": "bun test"
   },
   "dependencies": {
     "cors": "^2.8.6",

--- a/server/src/logic/GameEngine.calculateTrickPoints.test.ts
+++ b/server/src/logic/GameEngine.calculateTrickPoints.test.ts
@@ -1,0 +1,52 @@
+import { expect, test, describe } from "bun:test";
+import { GameEngine } from './GameEngine';
+import { CardValue, Suit, Card } from './types';
+
+describe('GameEngine.calculateTrickPoints', () => {
+  test('should return 0 for an empty trick', () => {
+    expect(GameEngine.calculateTrickPoints([])).toBe(0);
+  });
+
+  test('should correctly sum points for a standard trick', () => {
+    const trick: Card[] = [
+      { suit: Suit.Kreuz, value: CardValue.Ass, id: '1' },   // 11
+      { suit: Suit.Kreuz, value: CardValue.Zehn, id: '2' },  // 10
+      { suit: Suit.Kreuz, value: CardValue.Koenig, id: '3' }, // 4
+      { suit: Suit.Kreuz, value: CardValue.Dame, id: '4' },   // 3
+    ];
+    expect(GameEngine.calculateTrickPoints(trick)).toBe(28);
+  });
+
+  test('should correctly handle Bube and Neun', () => {
+    const trick: Card[] = [
+      { suit: Suit.Pik, value: CardValue.Bube, id: '5' }, // 2
+      { suit: Suit.Pik, value: CardValue.Neun, id: '6' }, // 0
+      { suit: Suit.Herz, value: CardValue.Ass, id: '7' }, // 11
+      { suit: Suit.Karo, value: CardValue.Zehn, id: '8' }, // 10
+    ];
+    expect(GameEngine.calculateTrickPoints(trick)).toBe(23);
+  });
+
+  test('should correctly sum points for all card values', () => {
+    const allValuesTrick: Card[] = [
+      { suit: Suit.Kreuz, value: CardValue.Ass, id: '1' },    // 11
+      { suit: Suit.Kreuz, value: CardValue.Zehn, id: '2' },   // 10
+      { suit: Suit.Kreuz, value: CardValue.Koenig, id: '3' }, // 4
+      { suit: Suit.Kreuz, value: CardValue.Dame, id: '4' },   // 3
+      { suit: Suit.Kreuz, value: CardValue.Bube, id: '5' },   // 2
+      { suit: Suit.Kreuz, value: CardValue.Neun, id: '6' },   // 0
+    ];
+    expect(GameEngine.calculateTrickPoints(allValuesTrick)).toBe(30);
+  });
+
+  test('should be independent of suits', () => {
+    const trick1: Card[] = [
+      { suit: Suit.Kreuz, value: CardValue.Ass, id: '1' },
+    ];
+    const trick2: Card[] = [
+      { suit: Suit.Karo, value: CardValue.Ass, id: '2' },
+    ];
+    expect(GameEngine.calculateTrickPoints(trick1)).toBe(GameEngine.calculateTrickPoints(trick2));
+    expect(GameEngine.calculateTrickPoints(trick1)).toBe(11);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of automated tests for the server-side `GameEngine.calculateTrickPoints` method, which is responsible for summing up the points in a trick.

📊 **Coverage:** The new tests cover several scenarios:
- **Empty trick:** Verifies that an empty array returns 0 points.
- **Standard trick:** Verifies a typical 4-card trick with mixed values.
- **Card values:** Explicitly checks all possible `CardValue` types (Ass, Zehn, König, Dame, Bube, Neun) to ensure they map correctly to their points.
- **Independence:** Verifies that the suit of a card does not affect its score.

✨ **Result:** Increased reliability of the scoring logic. By introducing a test runner (Bun) and a `test` script, we've established a foundation for further server-side unit testing.

---
*PR created automatically by Jules for task [6259316291456715215](https://jules.google.com/task/6259316291456715215) started by @MokkaMS*