### PR TITLE
🔒 Fix: Prevent arbitrary card play in executePlayCard

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -76,11 +76,24 @@ const executePlayCard = (roomId: string, playerId: string, card: Card) => {
   const currentPlayer = state.players[currentPlayerIndex];
   if (currentPlayer.id !== playerId) return;
 
-  const newHand = currentPlayer.hand.filter(c => c.id !== card.id);
-  const newTrick = [...state.currentTrick, card];
+  // Security: Verify card exists in player's hand
+  const cardInHand = currentPlayer.hand.find(c => c.id === card.id);
+  if (!cardInHand) {
+    console.warn(`Player ${playerId} attempted to play a card not in hand: ${JSON.stringify(card)}`);
+    return;
+  }
+
+  // Security: Verify move is valid according to game rules
+  if (!GameEngine.isValidMove(cardInHand, currentPlayer, state.currentTrick, state.gameType, state.trumpSuit, room.settings)) {
+    console.warn(`Player ${playerId} attempted an invalid move: ${JSON.stringify(cardInHand)}`);
+    return;
+  }
+
+  const newHand = currentPlayer.hand.filter(c => c.id !== cardInHand.id);
+  const newTrick = [...state.currentTrick, cardInHand];
   
   // Reveal team if Kreuz-Dame is played
-  if (card.suit === Suit.Kreuz && card.value === CardValue.Dame) {
+  if (cardInHand.suit === Suit.Kreuz && cardInHand.value === CardValue.Dame) {
       player.isRevealed = true;
   }
 


### PR DESCRIPTION
This PR addresses a critical security vulnerability in `server/src/index.ts` where a player could play any card, even if not in their hand, or make an invalid move.

Changes:
1.  Verify that the card played exists in the player's hand (using `currentPlayer.hand.find`).
2.  Verify that the move is valid according to game rules using `GameEngine.isValidMove`.
3.  Use the verified card object from the server's state for subsequent game logic instead of the client-provided card object.
4.  Log warnings for invalid attempts.

Verified by running a temporary script that simulated invalid moves and confirmed they were blocked.

---
*PR created automatically by Jules for task [8348182540824978673](https://jules.google.com/task/8348182540824978673) started by @MokkaMS*