### PR TITLE
Add tests for cardUtils logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "globals": "^16.5.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1373,6 +1374,13 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1417,6 +1425,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1765,6 +1791,117 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1827,6 +1964,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1920,6 +2067,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2046,6 +2203,13 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2286,6 +2450,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2294,6 +2468,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2655,6 +2839,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2705,6 +2899,17 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -2789,6 +2994,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2984,6 +3196,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/socket.io-client": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
@@ -3022,6 +3241,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3048,6 +3281,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3063,6 +3313,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3252,6 +3512,84 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3266,6 +3604,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "test": "vitest",
     "lint": "eslint .",
     "preview": "vite preview",
     "server": "cd server && npm start"
@@ -27,6 +28,7 @@
     "globals": "^16.5.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.0.18"
   }
 }

--- a/src/logic/__tests__/cardUtils.test.ts
+++ b/src/logic/__tests__/cardUtils.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isTrump,
+  getCardPower,
+  sortCards,
+  createDeck,
+  shuffle,
+} from '../cardUtils';
+import { Card, CardValue, Suit, GameType, GameSettings } from '../types';
+
+// Helper to create a card
+const createCard = (suit: Suit, value: CardValue): Card => ({
+  suit,
+  value,
+  id: `${suit}-${value}-0`,
+});
+
+const defaultSettings: GameSettings = {
+  mitNeunen: true,
+  dullenAlsHoechste: false,
+  schweinchen: false,
+  fuchsGefangen: false,
+  karlchen: false,
+  doppelkopfPunkte: false,
+  soloPrioritaet: false,
+};
+
+describe('cardUtils', () => {
+  describe('isTrump', () => {
+    it('should identify trumps in a Normal game', () => {
+      const settings = { ...defaultSettings };
+      // Normal game: Queens, Jacks, Diamonds (Karo) are trumps
+
+      // Queens
+      expect(isTrump(createCard(Suit.Herz, CardValue.Dame), GameType.Normal, null, settings)).toBe(true);
+      expect(isTrump(createCard(Suit.Pik, CardValue.Dame), GameType.Normal, null, settings)).toBe(true);
+
+      // Jacks
+      expect(isTrump(createCard(Suit.Kreuz, CardValue.Bube), GameType.Normal, null, settings)).toBe(true);
+      expect(isTrump(createCard(Suit.Karo, CardValue.Bube), GameType.Normal, null, settings)).toBe(true);
+
+      // Diamonds (Karo)
+      expect(isTrump(createCard(Suit.Karo, CardValue.Ass), GameType.Normal, null, settings)).toBe(true);
+      expect(isTrump(createCard(Suit.Karo, CardValue.Zehn), GameType.Normal, null, settings)).toBe(true);
+      expect(isTrump(createCard(Suit.Karo, CardValue.Neun), GameType.Normal, null, settings)).toBe(true);
+
+      // Non-trumps (Fehlfarben)
+      expect(isTrump(createCard(Suit.Herz, CardValue.Ass), GameType.Normal, null, settings)).toBe(false);
+      expect(isTrump(createCard(Suit.Pik, CardValue.Zehn), GameType.Normal, null, settings)).toBe(false);
+      expect(isTrump(createCard(Suit.Kreuz, CardValue.Koenig), GameType.Normal, null, settings)).toBe(false);
+    });
+
+    it('should handle "Dullen als höchste" setting', () => {
+      const settingsWithDulle = { ...defaultSettings, dullenAlsHoechste: true };
+      const settingsWithoutDulle = { ...defaultSettings, dullenAlsHoechste: false };
+
+      const herz10 = createCard(Suit.Herz, CardValue.Zehn);
+
+      // In Normal game, Herz 10 is NOT trump by default (it's a Fehlfarbe)
+      expect(isTrump(herz10, GameType.Normal, null, settingsWithoutDulle)).toBe(false);
+
+      // With setting, it IS trump
+      expect(isTrump(herz10, GameType.Normal, null, settingsWithDulle)).toBe(true);
+    });
+
+    it('should identify trumps in DamenSolo', () => {
+      const settings = { ...defaultSettings };
+      // Only Queens are trump
+      expect(isTrump(createCard(Suit.Herz, CardValue.Dame), GameType.DamenSolo, null, settings)).toBe(true);
+      expect(isTrump(createCard(Suit.Kreuz, CardValue.Dame), GameType.DamenSolo, null, settings)).toBe(true);
+
+      // Jacks are NOT trump
+      expect(isTrump(createCard(Suit.Kreuz, CardValue.Bube), GameType.DamenSolo, null, settings)).toBe(false);
+
+      // Diamonds are NOT trump
+      expect(isTrump(createCard(Suit.Karo, CardValue.Ass), GameType.DamenSolo, null, settings)).toBe(false);
+    });
+
+    it('should identify trumps in BubenSolo', () => {
+      const settings = { ...defaultSettings };
+      // Only Jacks are trump
+      expect(isTrump(createCard(Suit.Herz, CardValue.Bube), GameType.BubenSolo, null, settings)).toBe(true);
+
+      // Queens are NOT trump
+      expect(isTrump(createCard(Suit.Herz, CardValue.Dame), GameType.BubenSolo, null, settings)).toBe(false);
+    });
+
+    it('should identify trumps in FarbenSolo', () => {
+      const settings = { ...defaultSettings };
+      const trumpSuit = Suit.Pik;
+
+      // Queens and Jacks are always trump
+      expect(isTrump(createCard(Suit.Herz, CardValue.Dame), GameType.FarbenSolo, trumpSuit, settings)).toBe(true);
+      expect(isTrump(createCard(Suit.Karo, CardValue.Bube), GameType.FarbenSolo, trumpSuit, settings)).toBe(true);
+
+      // The chosen suit (Pik) is trump
+      expect(isTrump(createCard(Suit.Pik, CardValue.Ass), GameType.FarbenSolo, trumpSuit, settings)).toBe(true);
+      expect(isTrump(createCard(Suit.Pik, CardValue.Neun), GameType.FarbenSolo, trumpSuit, settings)).toBe(true);
+
+      // Diamonds (Karo) are NOT trump (unless they are Queens/Jacks)
+      expect(isTrump(createCard(Suit.Karo, CardValue.Ass), GameType.FarbenSolo, trumpSuit, settings)).toBe(false);
+    });
+
+    it('should identify trumps in Fleischlos', () => {
+      const settings = { ...defaultSettings };
+      // Nothing is trump
+      expect(isTrump(createCard(Suit.Herz, CardValue.Dame), GameType.Fleischlos, null, settings)).toBe(false);
+      expect(isTrump(createCard(Suit.Kreuz, CardValue.Bube), GameType.Fleischlos, null, settings)).toBe(false);
+      expect(isTrump(createCard(Suit.Karo, CardValue.Ass), GameType.Fleischlos, null, settings)).toBe(false);
+
+      // Even with DullenAlsHoechste?
+      // Based on code analysis:
+      // if (card.value === CardValue.Zehn && card.suit === Suit.Herz && settings.dullenAlsHoechste) return true;
+      // THEN check gameType.
+      // So Dulle IS trump in Fleischlos if setting is on.
+      const settingsWithDulle = { ...defaultSettings, dullenAlsHoechste: true };
+      const herz10 = createCard(Suit.Herz, CardValue.Zehn);
+      expect(isTrump(herz10, GameType.Fleischlos, null, settingsWithDulle)).toBe(true);
+    });
+  });
+
+  describe('getCardPower', () => {
+    it('should return correct power for trumps', () => {
+      const settings = { ...defaultSettings };
+
+      // Queens > Jacks > Diamonds
+      const queen = createCard(Suit.Kreuz, CardValue.Dame);
+      const jack = createCard(Suit.Kreuz, CardValue.Bube);
+      const diamondAce = createCard(Suit.Karo, CardValue.Ass);
+
+      const powerQ = getCardPower(queen, GameType.Normal, null, settings);
+      const powerJ = getCardPower(jack, GameType.Normal, null, settings);
+      const powerD = getCardPower(diamondAce, GameType.Normal, null, settings);
+
+      expect(powerQ).toBeGreaterThan(powerJ);
+      expect(powerJ).toBeGreaterThan(powerD);
+    });
+
+    it('should return correct power for non-trumps', () => {
+      const settings = { ...defaultSettings };
+      // Ace > Ten > King > Nine
+      const ace = createCard(Suit.Herz, CardValue.Ass);
+      const ten = createCard(Suit.Herz, CardValue.Zehn);
+      const king = createCard(Suit.Herz, CardValue.Koenig);
+      const nine = createCard(Suit.Herz, CardValue.Neun);
+
+      expect(getCardPower(ace, GameType.Normal, null, settings)).toBe(10);
+      expect(getCardPower(ten, GameType.Normal, null, settings)).toBe(9);
+      expect(getCardPower(king, GameType.Normal, null, settings)).toBe(8);
+      expect(getCardPower(nine, GameType.Normal, null, settings)).toBe(1);
+    });
+
+     it('should handle Dulle power', () => {
+        const settings = { ...defaultSettings, dullenAlsHoechste: true };
+        const dulle = createCard(Suit.Herz, CardValue.Zehn);
+        const queen = createCard(Suit.Kreuz, CardValue.Dame); // Highest normal trump
+
+        const powerDulle = getCardPower(dulle, GameType.Normal, null, settings);
+        const powerQueen = getCardPower(queen, GameType.Normal, null, settings);
+
+        expect(powerDulle).toBeGreaterThan(powerQueen);
+     });
+  });
+
+  describe('sortCards', () => {
+    it('should sort cards correctly (Trumps > Non-Trumps)', () => {
+      const settings = { ...defaultSettings };
+      const hand = [
+        createCard(Suit.Herz, CardValue.Ass), // Non-trump
+        createCard(Suit.Kreuz, CardValue.Dame), // High Trump
+        createCard(Suit.Karo, CardValue.Ass),   // Low Trump
+        createCard(Suit.Pik, CardValue.Zehn),   // Non-trump
+      ];
+
+      const sorted = sortCards(hand, GameType.Normal, null, settings);
+
+      // Expected: Kreuz Dame, Karo Ass, Herz Ass, Pik Zehn (or similar, depending on suit order for non-trumps)
+      // First two must be trumps
+      expect(isTrump(sorted[0], GameType.Normal, null, settings)).toBe(true);
+      expect(isTrump(sorted[1], GameType.Normal, null, settings)).toBe(true);
+      expect(isTrump(sorted[2], GameType.Normal, null, settings)).toBe(false);
+      expect(isTrump(sorted[3], GameType.Normal, null, settings)).toBe(false);
+
+      // Check specific order
+      // Kreuz Dame (Power > 1000) > Karo Ass (Power > 1000)
+      expect(sorted[0].value).toBe(CardValue.Dame);
+      expect(sorted[1].suit).toBe(Suit.Karo);
+    });
+  });
+
+  describe('createDeck', () => {
+    it('should create a deck with 48 cards (with nines)', () => {
+      const deck = createDeck(true);
+      expect(deck.length).toBe(48);
+    });
+
+    it('should create a deck with 40 cards (without nines)', () => {
+      const deck = createDeck(false);
+      expect(deck.length).toBe(40);
+    });
+  });
+
+  describe('shuffle', () => {
+      it('should return a deck with the same cards', () => {
+          const deck = createDeck(true);
+          const shuffled = shuffle(deck);
+
+          expect(shuffled.length).toBe(deck.length);
+          // Check that every card ID in deck is in shuffled
+          const deckIds = deck.map(c => c.id).sort();
+          const shuffledIds = shuffled.map(c => c.id).sort();
+          expect(deckIds).toEqual(shuffledIds);
+      });
+  });
+});


### PR DESCRIPTION
This PR adds a comprehensive test suite for the `src/logic/cardUtils.ts` file using Vitest.

### 🎯 What
- Installed `vitest`.
- Added a `test` script.
- Created unit tests for `isTrump`, `getCardPower`, `sortCards`, `createDeck`, and `shuffle`.

### 📊 Coverage
- **isTrump**: Validates trump identification for Normal, DamenSolo, BubenSolo, FarbenSolo, and Fleischlos games, including "Dullen als höchste" setting.
- **getCardPower**: Verifies card power values for trumps and non-trumps.
- **sortCards**: Ensures cards are sorted correctly (Trumps > Non-Trumps, then by power/suit).
- **createDeck**: Checks deck composition.
- **shuffle**: Checks shuffling integrity.

### ✨ Result
- Improved reliability of core game logic.
- 13 passing tests covering key scenarios.

---
*PR created automatically by Jules for task [9104991414616252177](https://jules.google.com/task/9104991414616252177) started by @MokkaMS*