### PR TITLE
feat: Run game entirely on server side (port 5173)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "vitest",
     "lint": "eslint .",
     "preview": "vite preview",
-    "server": "cd server && npm start"
+    "server": "cd server && npm start",
+    "start": "npm install && npm run build && cd server && npm install && npm run build && npm run serve"
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "start": "ts-node src/index.ts",
+    "serve": "node dist/index.js",
     "build": "tsc",
     "test": "bun test"
   },

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import http from 'http';
+import path from 'path';
 import { Server, Socket } from 'socket.io';
 import cors from 'cors';
 import { GameEngine } from './logic/GameEngine';
@@ -9,6 +10,9 @@ import { validatePlayerName } from './utils/validation';
 
 const app = express();
 app.use(cors());
+
+// Serve static files from the frontend build directory
+app.use(express.static(path.join(__dirname, '../../dist')));
 
 const server = http.createServer(app);
 const io = new Server(server, {
@@ -354,7 +358,12 @@ io.on('connection', (socket: Socket) => {
   });
 });
 
-const PORT = process.env.PORT || 3001;
+// Handle SPA routing: serve index.html for any unknown routes
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, '../../dist/index.html'));
+});
+
+const PORT = process.env.PORT || 5173;
 server.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -9,5 +9,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -4,7 +4,7 @@ import { Card, GameState, Player, GameSettings, GameType, Suit, CardValue } from
 import { GameEngine } from '../logic/GameEngine';
 import { Bot } from '../logic/Bot';
 
-const socket: Socket = io('http://localhost:3001', { autoConnect: false });
+const socket: Socket = io({ autoConnect: false });
 
 interface GameContextType {
   state: GameState;


### PR DESCRIPTION
This change enables the game to be run entirely from the server side with a single command (`npm start`). The backend now serves the frontend static files on port 5173, and the frontend connects to the server using a relative path. The build process handles dependency installation and compilation for both frontend and backend.

---
*PR created automatically by Jules for task [9173817909117126555](https://jules.google.com/task/9173817909117126555) started by @MokkaMS*