### PR TITLE
Prevent playing cards during Bidding phase

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -78,6 +78,7 @@ const executePlayCard = (roomId: string, playerId: string, card: Card) => {
   if (!room || !room.gameState) return;
 
   const state = room.gameState;
+  if (state.phase !== 'Playing') return;
   const player = state.players.find(p => p.id === playerId);
   if (!player) return;
 

--- a/src/App.css
+++ b/src/App.css
@@ -40,6 +40,7 @@ body { margin: 0; padding: 0; background-color: #0d4d1a; color: white; font-fami
 .card { width: 95px; height: 140px; background: white; border-radius: 10px; border: 1px solid #999; display: flex; flex-direction: column; justify-content: space-between; padding: 8px; color: black; position: relative; background: linear-gradient(135deg, #fff 0%, #eee 100%); box-shadow: 2px 2px 8px rgba(0,0,0,0.4); }
 .card.red { color: #d32f2f; }
 .card.black { color: #222; }
+.card.disabled { filter: grayscale(100%); opacity: 0.7; cursor: not-allowed; pointer-events: none; }
 
 .card-corner { font-size: 18px; font-weight: bold; line-height: 1; }
 .card-corner.bottom { align-self: flex-end; transform: rotate(180deg); }
@@ -145,4 +146,3 @@ body { margin: 0; padding: 0; background-color: #0d4d1a; color: white; font-fami
   background: #388e3c;
   transform: scale(1.05);
 }
-

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,15 +10,15 @@ import { SettingsScreen } from './components/SettingsScreen';
 const suitSymbols: Record<Suit, string> = { [Suit.Kreuz]: '♣', [Suit.Pik]: '♠', [Suit.Herz]: '♥', [Suit.Karo]: '♦' };
 const valueSymbols: Record<CardValue, string> = { [CardValue.Ass]: 'A', [CardValue.Zehn]: '10', [CardValue.Koenig]: 'K', [CardValue.Dame]: 'D', [CardValue.Bube]: 'B', [CardValue.Neun]: '9' };
 
-const CardComponent = memo<{ card: Card; onClick?: (card: Card) => void; className?: string }>(({ card, onClick, className }) => {
+const CardComponent = memo<{ card: Card; onClick?: (card: Card) => void; className?: string; disabled?: boolean }>(({ card, onClick, className, disabled }) => {
   const isRed = card.suit === Suit.Herz || card.suit === Suit.Karo;
   const handleClick = () => {
-    if (onClick) {
+    if (onClick && !disabled) {
       onClick(card);
     }
   };
   return (
-    <div className={`card ${isRed ? 'red' : 'black'} ${className || ''}`} onClick={handleClick}>
+    <div className={`card ${isRed ? 'red' : 'black'} ${className || ''} ${disabled ? 'disabled' : ''}`} onClick={handleClick}>
       <div className="card-corner top">{valueSymbols[card.value]}</div>
       <div className="card-center">{suitSymbols[card.suit]}</div>
       <div className="card-corner bottom">{valueSymbols[card.value]}</div>
@@ -154,7 +154,12 @@ const App: React.FC = () => {
 
       <div className="hand">
         {sortedHand.map(card => (
-          <CardComponent key={card.id} card={card} onClick={handlePlayCard}/>
+          <CardComponent
+            key={card.id}
+            card={card}
+            onClick={handlePlayCard}
+            disabled={state.phase !== 'Playing'}
+          />
         ))}
       </div>
 

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -106,6 +106,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
         socket.emit('play_card', { roomId, card });
         return;
     }
+    if (state.phase !== 'Playing') return;
     if (isCleaning) return;
     setState(prevState => {
       const currentPlayerIndex = prevState.currentPlayerIndex;


### PR DESCRIPTION
- **Backend**: Added a check in `server/src/index.ts` to reject `play_card` events if the game phase is not `Playing`.
- **Frontend Logic**: Added a check in `src/context/GameContext.tsx` to prevent local `playCard` execution if the phase is not `Playing`.
- **Frontend UI**: Updated `src/App.tsx` and `src/App.css` to visually disable cards (grayed out, unclickable) during the Bidding (Vorbehalt) phase.

This addresses the issue where users could play cards while choosing a Vorbehalt, breaking the game state.

---
*PR created automatically by Jules for task [10592282539371041100](https://jules.google.com/task/10592282539371041100) started by @MokkaMS*