### PR TITLE
Fix game stall caused by out-of-turn bidding

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -286,6 +286,17 @@ io.on('connection', (socket: Socket) => {
     const room = rooms[roomId];
     if (!room || !room.gameState) return;
     const state = room.gameState;
+
+    const currentPlayer = state.players[state.currentPlayerIndex];
+    if (currentPlayer.id !== playerId) {
+      console.warn(`Player ${playerId} attempted to bid out of turn. Expected: ${currentPlayer.id}`);
+      const playerSocket = room.players.find(p => p.id === playerId);
+      if (playerSocket?.socketId) {
+        io.to(playerSocket.socketId).emit('error', 'It is not your turn to bid.');
+      }
+      return;
+    }
+
     state.announcements[playerId] = [bid];
 
     if (Object.keys(state.announcements).length === 4) {


### PR DESCRIPTION
The user reported that bots would not start playing after making a decision in the bidding phase. Investigation revealed that if a user submitted a bid out of turn (e.g., due to UI enabling the button prematurely or a race condition), the server would accept the bid and increment the turn index. This caused the bot whose turn it actually was to be skipped. The skipped bot never bid, so the bidding phase never completed (waiting for 4 bids), and the game stalled.

This fix enforces strict turn order validation in the `submit_bid` handler. If a player attempts to bid out of turn, the server now logs a warning and emits an error to the client, preventing the state corruption. Verified with a reproduction script that simulated out-of-turn bidding.

---
*PR created automatically by Jules for task [8284349065344848504](https://jules.google.com/task/8284349065344848504) started by @MokkaMS*