### PR TITLE
Disable Herz 10 as Dulle in Solo games

### DIFF
--- a/server/src/logic/cardUtils.ts
+++ b/server/src/logic/cardUtils.ts
@@ -46,8 +46,9 @@ export const shuffle = (deck: Card[]): Card[] => {
 };
 
 export const isTrump = (card: Card, gameType: GameType, trumpSuit: Suit | null, settings: GameSettings): boolean => {
-  // Dulle ist immer Trumpf (außer bei bestimmten Solo-Varianten, hier vereinfacht)
-  if (card.value === CardValue.Zehn && card.suit === Suit.Herz && settings.dullenAlsHoechste) {
+  // Dulle ist immer Trumpf (außer bei bestimmten Solo-Varianten)
+  const isSolo = [GameType.DamenSolo, GameType.BubenSolo, GameType.FarbenSolo, GameType.Fleischlos].includes(gameType);
+  if (card.value === CardValue.Zehn && card.suit === Suit.Herz && settings.dullenAlsHoechste && !isSolo) {
     return true;
   }
 
@@ -76,7 +77,8 @@ export const getCardPower = (card: Card, gameType: GameType, trumpSuit: Suit | n
     let power = 1000;
     
     // Dulle
-    if (card.value === CardValue.Zehn && card.suit === Suit.Herz && settings.dullenAlsHoechste) {
+    const isSolo = [GameType.DamenSolo, GameType.BubenSolo, GameType.FarbenSolo, GameType.Fleischlos].includes(gameType);
+    if (card.value === CardValue.Zehn && card.suit === Suit.Herz && settings.dullenAlsHoechste && !isSolo) {
       return power + 100;
     }
 

--- a/src/logic/__tests__/cardUtils.test.ts
+++ b/src/logic/__tests__/cardUtils.test.ts
@@ -110,12 +110,10 @@ describe('cardUtils', () => {
 
       // Even with DullenAlsHoechste?
       // Based on code analysis:
-      // if (card.value === CardValue.Zehn && card.suit === Suit.Herz && settings.dullenAlsHoechste) return true;
-      // THEN check gameType.
-      // So Dulle IS trump in Fleischlos if setting is on.
+      // Dulle is NOT trump in Fleischlos if setting is on (Solo rule).
       const settingsWithDulle = { ...defaultSettings, dullenAlsHoechste: true };
       const herz10 = createCard(Suit.Herz, CardValue.Zehn);
-      expect(isTrump(herz10, GameType.Fleischlos, null, settingsWithDulle)).toBe(true);
+      expect(isTrump(herz10, GameType.Fleischlos, null, settingsWithDulle)).toBe(false);
     });
   });
 

--- a/src/logic/cardUtils.ts
+++ b/src/logic/cardUtils.ts
@@ -46,8 +46,9 @@ export const shuffle = (deck: Card[]): Card[] => {
 };
 
 export const isTrump = (card: Card, gameType: GameType, trumpSuit: Suit | null, settings: GameSettings): boolean => {
-  // Dulle ist immer Trumpf (außer bei bestimmten Solo-Varianten, hier vereinfacht)
-  if (card.value === CardValue.Zehn && card.suit === Suit.Herz && settings.dullenAlsHoechste) {
+  // Dulle ist immer Trumpf (außer bei bestimmten Solo-Varianten)
+  const isSolo = [GameType.DamenSolo, GameType.BubenSolo, GameType.FarbenSolo, GameType.Fleischlos].includes(gameType);
+  if (card.value === CardValue.Zehn && card.suit === Suit.Herz && settings.dullenAlsHoechste && !isSolo) {
     return true;
   }
 
@@ -76,7 +77,8 @@ export const getCardPower = (card: Card, gameType: GameType, trumpSuit: Suit | n
     let power = 1000;
     
     // Dulle
-    if (card.value === CardValue.Zehn && card.suit === Suit.Herz && settings.dullenAlsHoechste) {
+    const isSolo = [GameType.DamenSolo, GameType.BubenSolo, GameType.FarbenSolo, GameType.Fleischlos].includes(gameType);
+    if (card.value === CardValue.Zehn && card.suit === Suit.Herz && settings.dullenAlsHoechste && !isSolo) {
       return power + 100;
     }
 


### PR DESCRIPTION
This change ensures that Herz 10 is treated as a regular card (either a normal trump or a suit card, depending on the game type) in Solo games, even if the "Dulle als höchste" setting is active. This prevents Herz 10 from overpowering Solo games where it should not have special status.

Specific changes:
- Updated `src/logic/cardUtils.ts` and `server/src/logic/cardUtils.ts`.
- Updated `src/logic/__tests__/cardUtils.test.ts` to align with the new rule.
- Verified with a temporary test script covering all game types.
- Verified existing tests pass.

---
*PR created automatically by Jules for task [12808888034848779668](https://jules.google.com/task/12808888034848779668) started by @MokkaMS*