### PR TITLE
🔒 Fix Insecure CORS Configuration

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -9,7 +9,16 @@ import { Bot } from './logic/Bot';
 import { validatePlayerName } from './utils/validation';
 
 const app = express();
-app.use(cors());
+
+const allowedOrigins = process.env.CORS_ALLOWED_ORIGINS
+  ? process.env.CORS_ALLOWED_ORIGINS.split(',').map(o => o.trim())
+  : ["http://localhost:5173", "http://127.0.0.1:5173"];
+
+app.use(cors({
+  origin: allowedOrigins,
+  methods: ["GET", "POST"],
+  credentials: true
+}));
 
 // Serve static files from the frontend build directory
 app.use(express.static(path.join(__dirname, '../../dist')));
@@ -17,8 +26,9 @@ app.use(express.static(path.join(__dirname, '../../dist')));
 const server = http.createServer(app);
 const io = new Server(server, {
   cors: {
-    origin: "*",
-    methods: ["GET", "POST"]
+    origin: allowedOrigins,
+    methods: ["GET", "POST"],
+    credentials: true
   }
 });
 


### PR DESCRIPTION
This PR addresses a security vulnerability where the server was configured with `origin: "*"` for CORS, allowing any website to connect to the backend.

Changes:
- Replaced the wildcard origin with a configurable list of allowed origins.
- Added logic to parse the `CORS_ALLOWED_ORIGINS` environment variable (comma-separated).
- Set default allowed origins to `http://localhost:5173` and `http://127.0.0.1:5173` for development convenience.
- Ensured consistent CORS configuration across Express and Socket.IO.


---
*PR created automatically by Jules for task [15295184856690265492](https://jules.google.com/task/15295184856690265492) started by @MokkaMS*