### PR TITLE
Fix Singleplayer Bot Stall and Multiplayer Reconnect

### DIFF
--- a/src/logic/Bot.ts
+++ b/src/logic/Bot.ts
@@ -4,6 +4,10 @@ import { isTrump, getCardPower } from './cardUtils';
 
 export class Bot {
   static decideMove(player: Player, state: GameState, settings: GameSettings): Card {
+    if (!player.hand || player.hand.length === 0) {
+      throw new Error(`Bot ${player.name} has no cards!`);
+    }
+
     const legalMoves = player.hand.filter(card =>
       GameEngine.isValidMove(card, player, state.currentTrick, state.gameType, state.trumpSuit, settings)
     );

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -13,3 +13,15 @@ export const getStoredPlayerId = (): string => {
 
   return storedId;
 };
+
+export const getStoredRoomId = (): string | null => {
+  return localStorage.getItem('doppelkopf_room_id');
+};
+
+export const setStoredRoomId = (roomId: string | null) => {
+  if (roomId) {
+    localStorage.setItem('doppelkopf_room_id', roomId);
+  } else {
+    localStorage.removeItem('doppelkopf_room_id');
+  }
+};


### PR DESCRIPTION
This PR addresses two issues:
1.  **Singleplayer Bots Stalling:** Bots would sometimes not play after the bidding phase. Added defensive checks and error handling in the Frontend Bot logic and GameContext loop to prevent silent failures and ensure the game loop continues or at least logs errors.
2.  **Multiplayer Reconnection:** Clicking "Weiterspielen" (Resume) after leaving a Multiplayer session would result in a stuck state because the client lost the `roomId`. Implemented `localStorage` persistence for `roomId` and updated `resumeGame` to attempt a socket reconnection and room join if a stored room ID exists. Also ensured that starting a Singleplayer game clears this stored ID to avoid conflicts.

---
*PR created automatically by Jules for task [12542192111143789062](https://jules.google.com/task/12542192111143789062) started by @MokkaMS*