### PR TITLE
Hide 'Augen' points during active gameplay

### DIFF
--- a/src/components/GameTable.tsx
+++ b/src/components/GameTable.tsx
@@ -69,7 +69,10 @@ export const GameTable: React.FC = () => {
                 </span>
                 {state.currentPlayerIndex === idx && <span className="current-turn-indicator">★</span>}
               </div>
-              <span className="player-points">{p.tournamentPoints} Pkt ({p.points} A)</span>
+              <span className="player-points">
+                {p.tournamentPoints} Pkt
+                {state.phase === 'Scoring' && ` (${p.points} A)`}
+              </span>
               <div className="badges-row">
                 {(p.id === humanPlayer.id || p.isRevealed || state.phase === 'Scoring') && (
                     <div className="team-badge">{p.team}</div>


### PR DESCRIPTION
This change hides the current game points ("Augen") displayed next to the player's name during the round. The points are now only revealed at the end of the round (Scoring phase), while the long-term tournament points remain visible throughout the game. This prevents players from knowing exact point counts during gameplay, as requested.

---
*PR created automatically by Jules for task [11868156169344774159](https://jules.google.com/task/11868156169344774159) started by @MokkaMS*