### PR TITLE
Implement Re/Kontra announcements validation and scoring

### DIFF
--- a/server/src/logic/GameEngine.ts
+++ b/server/src/logic/GameEngine.ts
@@ -252,7 +252,31 @@ export class GameEngine {
         kontraDetails.push(sp);
     });
 
-    // 6. Net Calculation
+    // 6. Announcements
+    const reAnnounced = Object.values(state.reKontraAnnouncements).includes('Re');
+    const kontraAnnounced = Object.values(state.reKontraAnnouncements).includes('Kontra');
+
+    if (reAnnounced) {
+        if (winner === 'Re') {
+            reGamePoints += 1;
+            reDetails.push('Re angesagt');
+        } else {
+            kontraGamePoints += 1;
+            kontraDetails.push('Re verloren');
+        }
+    }
+
+    if (kontraAnnounced) {
+        if (winner === 'Kontra') {
+            kontraGamePoints += 1;
+            kontraDetails.push('Kontra angesagt');
+        } else {
+            reGamePoints += 1;
+            reDetails.push('Kontra verloren');
+        }
+    }
+
+    // 7. Net Calculation
     let netScore = 0;
     if (winner === 'Re') {
         netScore = reGamePoints - kontraGamePoints;
@@ -269,7 +293,7 @@ export class GameEngine {
         }
     });
 
-    // 7. Store Result
+    // 8. Store Result
     const result: ScoringResult = {
         winner,
         winningPoints: netScore,


### PR DESCRIPTION
Implemented the logic for Re/Kontra announcements in the backend. 
- Modified `server/src/index.ts` to validate that a player can only announce their own team and must do so before playing their second card.
- Modified `server/src/logic/GameEngine.ts` to calculate scores based on these announcements: +1 if the announcing team wins, +1 to the opponent if the announcing team loses. Handles multiple announcements from the same team correctly (max +1).

---
*PR created automatically by Jules for task [12271732824171390365](https://jules.google.com/task/12271732824171390365) started by @MokkaMS*