### PR TITLE
Fix infinite wait bug caused by card spamming and playing into full trick

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -56,6 +56,7 @@ const BOT_TURN_DELAY_MS = 1000;
 const BOT_BID_DELAY_MS = 500;
 const TRICK_EVALUATION_DELAY_MS = 1500;
 const lastRoomCreation: Map<string, number> = new Map();
+const lastPlayerActionTime: Map<string, number> = new Map();
 
 // Helper to generate room ID
 const generateRoomId = () => {
@@ -136,6 +137,20 @@ const executePlayCard = (roomId: string, playerId: string, card: Card) => {
 
   const state = room.gameState;
   if (state.phase !== 'Playing') return;
+
+  // Prevent playing into a full trick (waiting for evaluation)
+  if (state.currentTrick.length >= 4) {
+    return;
+  }
+
+  // Debounce player actions
+  const now = Date.now();
+  const lastTime = lastPlayerActionTime.get(playerId);
+  if (lastTime && (now - lastTime) < 500) {
+    return;
+  }
+  lastPlayerActionTime.set(playerId, now);
+
   const player = state.players.find(p => p.id === playerId);
   if (!player) return;
 

--- a/src/components/GameTable.tsx
+++ b/src/components/GameTable.tsx
@@ -7,12 +7,19 @@ import { CardComponent } from './CardComponent';
 export const GameTable: React.FC = () => {
   const { state, playCard, submitBid, announceReKontra, settings, goToMainMenu, playerId, startNewGame } = useGame();
   const [showFarbenSoloSelection, setShowFarbenSoloSelection] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  // Reset processing state when game state updates
+  React.useEffect(() => {
+    setIsProcessing(false);
+  }, [state]);
 
   // In Multiplayer, find "me". In Singleplayer, it is index 0.
   const humanPlayer = (playerId ? state.players.find(p => p.id === playerId || p.socketId === playerId) : state.players[0]) || state.players[0];
 
   const handlePlayCard = useCallback((card: Card) => {
     if (humanPlayer) {
+      setIsProcessing(true);
       playCard(humanPlayer.id, card);
     }
   }, [playCard, humanPlayer?.id]);
@@ -134,7 +141,7 @@ export const GameTable: React.FC = () => {
             key={card.id}
             card={card}
             onClick={handlePlayCard}
-            disabled={state.phase !== 'Playing'}
+            disabled={state.phase !== 'Playing' || isProcessing || state.currentTrick.length >= 4}
           />
         ))}
       </div>


### PR DESCRIPTION
This change fixes a critical bug where players could play multiple cards in a single turn by spam-clicking, or play into a full trick during the evaluation delay, leading to a corrupted game state (hand size mismatch) and infinite wait.

Changes:
- `src/components/GameTable.tsx`: Added `isProcessing` state to lock UI on click. Visual disable for full tricks.
- `server/src/index.ts`: Added `if (trick.length >= 4)` check and `lastPlayerActionTime` debounce.

---
*PR created automatically by Jules for task [15244797785083688757](https://jules.google.com/task/15244797785083688757) started by @MokkaMS*