### PR TITLE
Replace grayscale with opacity for disabled cards to improve suit visibility

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -40,7 +40,7 @@ body { margin: 0; padding: 0; background-color: #0d4d1a; color: white; font-fami
 .card { width: 95px; height: 140px; background: white; border-radius: 10px; border: 1px solid #999; display: flex; flex-direction: column; justify-content: space-between; padding: 8px; color: black; position: relative; background: linear-gradient(135deg, #fff 0%, #eee 100%); box-shadow: 2px 2px 8px rgba(0,0,0,0.4); }
 .card.red { color: #d32f2f; }
 .card.black { color: #222; }
-.card.disabled { filter: grayscale(100%); opacity: 0.7; cursor: not-allowed; pointer-events: none; }
+.card.disabled { opacity: 0.6; cursor: not-allowed; pointer-events: none; }
 
 .card-corner { font-size: 18px; font-weight: bold; line-height: 1; }
 .card-corner.bottom { align-self: flex-end; transform: rotate(180deg); }


### PR DESCRIPTION
- Modified `src/App.css` to remove `filter: grayscale(100%)` from `.card.disabled`.
- Adjusted `opacity` of `.card.disabled` to `0.6` to provide a clear visual cue for the disabled state without stripping color.
- Verified the change using a Playwright script that captured a screenshot of the Bidding phase, confirming cards are colorful but dimmed.

---
*PR created automatically by Jules for task [10832903488612960834](https://jules.google.com/task/10832903488612960834) started by @MokkaMS*