### PR TITLE
feat: Automatically reveal remaining players when one team is fully revealed

### DIFF
--- a/server/src/logic/GameEngine.ts
+++ b/server/src/logic/GameEngine.ts
@@ -128,6 +128,35 @@ export class GameEngine {
     }));
   }
 
+  static checkAndRevealRemainingPlayers(state: GameState): void {
+    const reIds = state.rePlayerIds;
+    const kontraIds = state.kontraPlayerIds;
+
+    // Only apply this logic for 2v2 situations (Standard Normal or Hochzeit with Partner)
+    if (reIds.length !== 2 || kontraIds.length !== 2) {
+      return;
+    }
+
+    const revealedReCount = state.players.filter(p => p.team === 'Re' && p.isRevealed).length;
+    const revealedKontraCount = state.players.filter(p => p.team === 'Kontra' && p.isRevealed).length;
+
+    if (revealedReCount === 2) {
+      // Reveal all Kontra
+      state.players.forEach(p => {
+        if (p.team === 'Kontra' && !p.isRevealed) {
+          p.isRevealed = true;
+        }
+      });
+    } else if (revealedKontraCount === 2) {
+      // Reveal all Re
+      state.players.forEach(p => {
+        if (p.team === 'Re' && !p.isRevealed) {
+          p.isRevealed = true;
+        }
+      });
+    }
+  }
+
   static isValidMove(card: Card, player: Player, trick: Card[], gameType: GameType, trumpSuit: Suit | null, settings: GameSettings): boolean {
     if (trick.length === 0) return true;
 


### PR DESCRIPTION
Implemented logic to automatically reveal the team affiliation of the remaining two players once two players of the same team (Re or Kontra) have been revealed. This applies to standard Normal games and Hochzeit games once the partner is found. This prevents information asymmetry in 2v2 scenarios.

---
*PR created automatically by Jules for task [2910015572724432722](https://jules.google.com/task/2910015572724432722) started by @MokkaMS*