### PR TITLE
Update trick completion animation sequence

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -54,7 +54,7 @@ const MAX_ROOMS = 100;
 const CREATE_ROOM_RATE_LIMIT = 2000; // 2 seconds
 const BOT_TURN_DELAY_MS = 1000;
 const BOT_BID_DELAY_MS = 500;
-const TRICK_EVALUATION_DELAY_MS = 3000;
+const TRICK_EVALUATION_DELAY_MS = 5000;
 const lastRoomCreation: Map<string, number> = new Map();
 const lastPlayerActionTime: Map<string, number> = new Map();
 

--- a/src/App.css
+++ b/src/App.css
@@ -87,6 +87,27 @@ body { margin: 0; padding: 0; background-color: #0d4d1a; color: white; font-fami
 .tcc-2 { top: 140px; left: 50%; transform: translateX(-50%); animation: p2In 0.4s ease-out; }
 .tcc-3 { right: 160px; top: 50%; transform: translateY(-50%); animation: p3In 0.4s ease-out; }
 
+/* Animation to Center (Pile) */
+.tcc-0.move-to-center {
+  bottom: 50%;
+  transform: translate(-50%, 50%);
+}
+
+.tcc-1.move-to-center {
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.tcc-2.move-to-center {
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.tcc-3.move-to-center {
+  right: 50%;
+  transform: translate(50%, -50%);
+}
+
 /* Animation to Winner */
 .move-to-player-0 {
   bottom: 20px !important;


### PR DESCRIPTION
Updated the trick completion animation to follow a 3-step sequence: wait on table, move to center (stacking perfectly), then move to the winner. This involved increasing the backend delay to 5 seconds and implementing a state machine in the frontend component.

---
*PR created automatically by Jules for task [12258589751182434721](https://jules.google.com/task/12258589751182434721) started by @MokkaMS*