### PR TITLE
Fix GameTable.tsx TypeScript build error

### DIFF
--- a/src/components/GameTable.tsx
+++ b/src/components/GameTable.tsx
@@ -29,8 +29,8 @@ export const GameTable: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    let timer1: NodeJS.Timeout;
-    let timer2: NodeJS.Timeout;
+    let timer1: ReturnType<typeof setTimeout>;
+    let timer2: ReturnType<typeof setTimeout>;
 
     if (state.currentTrick.length === 4) {
       setTrickAnimationPhase('waiting');


### PR DESCRIPTION
Replaced `NodeJS.Timeout` with `ReturnType<typeof setTimeout>` in `src/components/GameTable.tsx` to resolve a TypeScript build error where the `NodeJS` namespace was not found in the frontend environment. This ensures compatibility with the browser-based build configuration.

---
*PR created automatically by Jules for task [7467100445638944360](https://jules.google.com/task/7467100445638944360) started by @MokkaMS*