### PR TITLE
Rename Multiplayer to Spielen and Fix Input Visibility

### DIFF
--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -18,7 +18,7 @@ export const MainMenu: React.FC<MainMenuProps> = ({ showMultiplayer, setShowMult
     <div className="game-container main-menu">
       <h1 className="menu-title">DOPPELKOPF</h1>
       <div className="menu-content">
-        <button className="menu-button" onClick={() => setShowMultiplayer(true)}>Multiplayer</button>
+        <button className="menu-button" onClick={() => setShowMultiplayer(true)}>Spielen</button>
         {state.lastActivePhase && state.lastActivePhase !== 'Scoring' && (
            <button className="menu-button" onClick={resumeGame}>Weiterspielen</button>
         )}

--- a/src/components/MultiplayerSetup.tsx
+++ b/src/components/MultiplayerSetup.tsx
@@ -16,16 +16,16 @@ export const MultiplayerSetup: React.FC<{ onBack: () => void }> = ({ onBack }) =
 
   return (
     <div className="game-container main-menu">
-      <h1 className="menu-title">MULTIPLAYER</h1>
+      <h1 className="menu-title">SPIELEN</h1>
       <div className="settings-box">
         <div className="settings-grid">
-           <label>Dein Name: <input value={name} onChange={e => setName(e.target.value)} style={{color:'black', marginLeft:'10px', padding:'5px', fontSize:'18px'}}/></label>
+           <label>Dein Name: <input value={name} onChange={e => setName(e.target.value)} style={{backgroundColor: 'white', color:'black', marginLeft:'10px', padding:'5px', fontSize:'18px'}}/></label>
         </div>
         <div className="menu-content" style={{gap: '15px', marginTop: '20px'}}>
             <button className="menu-button" onClick={handleCreate}>Neues Spiel erstellen</button>
             
             <div style={{display:'flex', gap:'10px', alignItems:'center', justifyContent:'center'}}>
-                <input placeholder="Raum ID" value={roomId} onChange={e => setRoomId(e.target.value)} style={{padding:'10px', fontSize:'18px', borderRadius:'8px', border:'none', width:'120px'}}/>
+                <input placeholder="Raum ID" value={roomId} onChange={e => setRoomId(e.target.value)} style={{backgroundColor: 'white', color: 'black', padding:'10px', fontSize:'18px', borderRadius:'8px', border:'none', width:'120px'}}/>
                 <button className="menu-button" onClick={handleJoin}>Beitreten</button>
             </div>
             <button className="menu-button" onClick={onBack} style={{marginTop:'20px', background:'#555'}}>Zurück</button>


### PR DESCRIPTION
Renamed the 'Multiplayer' menu item to 'Spielen' and updated the input fields on the setup screen to have a white background with black text, addressing visibility issues. Verified visually with screenshots.

---
*PR created automatically by Jules for task [14072534305145714665](https://jules.google.com/task/14072534305145714665) started by @MokkaMS*