### PR TITLE
Auto-reconnect to game on browser refresh

### DIFF
--- a/src/components/MultiplayerSetup.tsx
+++ b/src/components/MultiplayerSetup.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { useGame } from '../context/GameContext';
+import { getStoredPlayerName } from '../utils/storage';
 
 export const MultiplayerSetup: React.FC<{ onBack: () => void }> = ({ onBack }) => {
   const { joinGame, createGame } = useGame();
-  const [name, setName] = useState('');
+  const [name, setName] = useState(() => getStoredPlayerName() || '');
   const [roomId, setRoomId] = useState('');
 
   const handleJoin = () => {

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { io, Socket } from 'socket.io-client';
 import { Card, GameState, GameSettings, GameType } from '../logic/types';
-import { getStoredPlayerId, getStoredRoomId, setStoredRoomId } from '../utils/storage';
+import { getStoredPlayerId, getStoredRoomId, setStoredRoomId, getStoredPlayerName, setStoredPlayerName } from '../utils/storage';
 
 const socket: Socket = io({ autoConnect: false });
 
@@ -64,6 +64,17 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
   useEffect(() => {
     socket.connect();
 
+    const storedRoomId = getStoredRoomId();
+    const storedPlayerName = getStoredPlayerName();
+
+    if (storedRoomId && playerId) {
+      socket.emit('join_room', {
+        roomId: storedRoomId,
+        playerName: storedPlayerName || 'Player',
+        playerId
+      });
+    }
+
     socket.on('room_created', ({ roomId, players, settings }: { roomId: string, players: any[], settings: GameSettings }) => {
       setRoomId(roomId);
       setStoredRoomId(roomId);
@@ -91,6 +102,9 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
     });
     
     socket.on('error', (msg: string) => {
+        if (msg === 'Room not found') {
+            setStoredRoomId(null);
+        }
         alert(msg);
     });
 
@@ -103,7 +117,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
       socket.off('error');
       socket.disconnect();
     };
-  }, []);
+  }, [playerId]);
 
   const announceReKontra = useCallback((pid: string, type: 'Re' | 'Kontra') => {
     if (roomId) {
@@ -160,10 +174,12 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, []);
 
   const joinGame = (rid: string, pname: string) => {
+      setStoredPlayerName(pname);
       socket.emit('join_room', { roomId: rid, playerName: pname, playerId });
   };
 
   const createGame = (pname: string) => {
+      setStoredPlayerName(pname);
       socket.emit('create_room', { playerName: pname, playerId });
   };
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -25,3 +25,15 @@ export const setStoredRoomId = (roomId: string | null) => {
     localStorage.removeItem('doppelkopf_room_id');
   }
 };
+
+export const getStoredPlayerName = (): string | null => {
+  return localStorage.getItem('doppelkopf_player_name');
+};
+
+export const setStoredPlayerName = (name: string) => {
+  if (name) {
+    localStorage.setItem('doppelkopf_player_name', name);
+  } else {
+    localStorage.removeItem('doppelkopf_player_name');
+  }
+};


### PR DESCRIPTION
This change enables users to refresh the browser without losing their game session. By storing the `roomId` and `playerId` in `localStorage`, the frontend automatically attempts to reconnect to the existing room upon reload. The player's name is also persisted to improve the user experience when joining or creating games.

---
*PR created automatically by Jules for task [17303709300956176635](https://jules.google.com/task/17303709300956176635) started by @MokkaMS*