### PR TITLE
Fix: Enable creating new room after leaving game

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -309,6 +309,38 @@ io.on('connection', (socket: Socket) => {
     socket.emit('room_created', { roomId, players: rooms[roomId].players, settings: rooms[roomId].settings });
   });
 
+  socket.on('leave_room', ({ roomId }: { roomId: string }) => {
+    const room = rooms[roomId];
+    if (room) {
+        const player = room.players.find(p => p.socketId === socket.id);
+        if (player) {
+            // Remove player
+            const idx = room.players.indexOf(player);
+            if (idx !== -1) {
+                room.players.splice(idx, 1);
+            }
+
+            // Clear disconnect timeout if exists
+            const timer = disconnectTimeouts.get(player.id);
+            if (timer) {
+                clearTimeout(timer);
+                disconnectTimeouts.delete(player.id);
+            }
+
+            socket.leave(roomId);
+
+            if (room.players.length === 0) {
+                delete rooms[roomId];
+            } else {
+                io.to(roomId).emit('player_left', room.players);
+                io.to(roomId).emit('player_joined', room.players); // Update lists
+            }
+
+            socket.emit('left_room');
+        }
+    }
+  });
+
   socket.on('join_room', ({ roomId, playerName, playerId }: { roomId: string, playerName: string, playerId: string }) => {
     const error = validatePlayerName(playerName);
     if (error) {

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -154,8 +154,8 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const goToMainMenu = useCallback(() => {
     if (roomId) {
-        socket.disconnect();
-        // Do NOT setRoomId(null) in storage.
+        socket.emit('leave_room', { roomId });
+        setStoredRoomId(null);
         setRoomId(null);
     }
     setState(prev => ({ ...prev, phase: 'MainMenu', lastActivePhase: prev.phase as any }));
@@ -175,11 +175,13 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const joinGame = (rid: string, pname: string) => {
       setStoredPlayerName(pname);
+      if (!socket.connected) socket.connect();
       socket.emit('join_room', { roomId: rid, playerName: pname, playerId });
   };
 
   const createGame = (pname: string) => {
       setStoredPlayerName(pname);
+      if (!socket.connected) socket.connect();
       socket.emit('create_room', { playerName: pname, playerId });
   };
 


### PR DESCRIPTION
This PR fixes a bug where players could not create a new room after leaving a game because the server held their session in a "disconnected" state for 120 seconds. The fix implements an explicit `leave_room` flow that cleans up the server state immediately, allowing the user to create a new room instantly. Verified with a reproduction script.

---
*PR created automatically by Jules for task [6763737348704528373](https://jules.google.com/task/6763737348704528373) started by @MokkaMS*