### PR TITLE
Public Lobbies and Kick Functionality

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -45,6 +45,8 @@ interface Room {
   }[];
   gameState: GameState | null;
   settings: GameSettings;
+  hostId: string;
+  isPublic: boolean;
 }
 
 const rooms: Record<string, Room> = Object.create(null);
@@ -262,6 +264,7 @@ io.on('connection', (socket: Socket) => {
   console.log('User connected:', socket.id);
 
   socket.on('create_room', ({ playerName, playerId }: { playerName: string, playerId: string }) => {
+    console.log(`[create_room] Request from ${playerName} (${playerId})`);
     // 1. Check Global Limit
     if (Object.keys(rooms).length >= MAX_ROOMS) {
       socket.emit('error', 'Server is full (max 100 rooms)');
@@ -303,10 +306,20 @@ io.on('connection', (socket: Socket) => {
           connected: true
       }],
       gameState: null,
-      settings: { ...defaultSettings }
+      settings: { ...defaultSettings },
+      hostId: playerId,
+      isPublic: false
     };
     socket.join(roomId);
-    socket.emit('room_created', { roomId, players: rooms[roomId].players, settings: rooms[roomId].settings });
+    socket.emit('room_created', {
+        roomId,
+        players: rooms[roomId].players,
+        settings: rooms[roomId].settings,
+        hostId: rooms[roomId].hostId,
+        isPublic: rooms[roomId].isPublic
+    });
+    io.emit('public_rooms_update', getPublicRooms());
+    console.log(`[create_room] Room ${roomId} created by ${playerName}`);
   });
 
   socket.on('leave_room', ({ roomId }: { roomId: string }) => {
@@ -332,6 +345,15 @@ io.on('connection', (socket: Socket) => {
             if (room.players.length === 0) {
                 delete rooms[roomId];
             } else {
+                // Transfer host if needed
+                if (room.hostId === player.id) {
+                    const nextHost = room.players.find(p => !p.isBot && p.connected);
+                    if (nextHost) {
+                        room.hostId = nextHost.id;
+                        io.to(roomId).emit('room_update', { hostId: room.hostId, isPublic: room.isPublic });
+                    }
+                }
+
                 io.to(roomId).emit('player_left', room.players);
                 io.to(roomId).emit('player_joined', room.players); // Update lists
             }
@@ -342,6 +364,7 @@ io.on('connection', (socket: Socket) => {
   });
 
   socket.on('join_room', ({ roomId, playerName, playerId }: { roomId: string, playerName: string, playerId: string }) => {
+    console.log(`[join_room] Request from ${playerName} (${playerId}) to join ${roomId}`);
     const error = validatePlayerName(playerName);
     if (error) {
       socket.emit('error', error);
@@ -365,7 +388,13 @@ io.on('connection', (socket: Socket) => {
           socket.join(roomId);
           io.to(roomId).emit('player_joined', room.players);
 
-          socket.emit('joined_room', { roomId, players: room.players, settings: room.settings });
+          socket.emit('joined_room', {
+              roomId,
+              players: room.players,
+              settings: room.settings,
+              hostId: room.hostId,
+              isPublic: room.isPublic
+          });
           if (room.gameState) {
              const sanitized = sanitizeState(room.gameState, playerId);
              socket.emit('game_state_update', sanitized);
@@ -384,33 +413,59 @@ io.on('connection', (socket: Socket) => {
               connected: true
           });
           socket.join(roomId);
+          console.log(`[join_room] ${playerName} joined ${roomId}. Players: ${room.players.map(p => p.name).join(', ')}`);
+
           io.to(roomId).emit('player_joined', room.players);
-          socket.emit('joined_room', { roomId, players: room.players, settings: room.settings });
+
+          socket.emit('joined_room', {
+              roomId,
+              players: room.players,
+              settings: room.settings,
+              hostId: room.hostId,
+              isPublic: room.isPublic
+          });
       }
     } else {
+      console.log(`[join_room] Room ${roomId} not found for ${playerName}`);
       socket.emit('error', 'Room not found');
     }
   });
 
   socket.on('add_bot', (roomId: string) => {
     const room = rooms[roomId];
-    if (room && room.players.length < 4) {
-      const botId = `bot-${Math.random().toString(36).substr(2, 5)}`;
-      room.players.push({
-          id: botId,
-          name: `Bot ${room.players.length}`,
-          socketId: botId,
-          ready: true,
-          isBot: true,
-          connected: true
-      });
-      io.to(roomId).emit('player_joined', room.players);
+    if (room) {
+        // Validate host
+        const requester = room.players.find(p => p.socketId === socket.id);
+        if (!requester || requester.id !== room.hostId) {
+            socket.emit('error', 'Only the host can add bots.');
+            return;
+        }
+
+        if (room.players.length < 4) {
+            const botId = `bot-${Math.random().toString(36).substr(2, 5)}`;
+            room.players.push({
+                id: botId,
+                name: `Bot ${room.players.length}`,
+                socketId: botId,
+                ready: true,
+                isBot: true,
+                connected: true
+            });
+            io.to(roomId).emit('player_joined', room.players);
+        }
     }
   });
 
   socket.on('start_game', (roomId: string) => {
     const room = rooms[roomId];
     if (room) {
+      // Validate host
+      const requester = room.players.find(p => p.socketId === socket.id);
+      if (!requester || requester.id !== room.hostId) {
+          socket.emit('error', 'Only the host can start the game.');
+          return;
+      }
+
       // Auto-fill with bots if less than 4
       while (room.players.length < 4) {
         const botId = `bot-${Math.random().toString(36).substr(2, 5)}`;
@@ -447,6 +502,10 @@ io.on('connection', (socket: Socket) => {
 
       const stateWithTeams = GameEngine.determineTeams(initialState);
       room.gameState = stateWithTeams;
+
+      // When game starts, it's no longer a public "lobby" effectively, but we can keep isPublic flag true.
+      // The filter for public lobbies will check gameState === null.
+
       emitToRoom(roomId, 'game_started', stateWithTeams);
       
       // If first player is a bot, start its turn
@@ -466,6 +525,84 @@ io.on('connection', (socket: Socket) => {
       }
     }
   });
+
+  socket.on('toggle_public', ({ roomId }: { roomId: string }) => {
+    const room = rooms[roomId];
+    if (room) {
+       const player = room.players.find(p => p.socketId === socket.id);
+       if (player && room.hostId === player.id) {
+          room.isPublic = !room.isPublic;
+          console.log(`[toggle_public] Room ${roomId} is now ${room.isPublic ? 'Public' : 'Private'}`);
+          io.to(roomId).emit('room_update', { hostId: room.hostId, isPublic: room.isPublic });
+          io.emit('public_rooms_update', getPublicRooms());
+       } else {
+          console.log(`[toggle_public] Failed: User is not host or not in room. Host: ${room.hostId}, Requester: ${player?.id}`);
+       }
+    } else {
+       console.log(`[toggle_public] Room ${roomId} not found`);
+    }
+  });
+
+  socket.on('kick_player', ({ roomId, targetId }: { roomId: string, targetId: string }) => {
+    const room = rooms[roomId];
+    if (!room) return;
+
+    const requester = room.players.find(p => p.socketId === socket.id);
+    if (!requester || requester.id !== room.hostId) {
+        socket.emit('error', 'Only the host can kick players.');
+        return;
+    }
+
+    if (targetId === requester.id) {
+        socket.emit('error', 'You cannot kick yourself.');
+        return;
+    }
+
+    const targetPlayer = room.players.find(p => p.id === targetId);
+    if (!targetPlayer) return;
+
+    if (targetPlayer.isBot) {
+        // Remove bot
+        const idx = room.players.indexOf(targetPlayer);
+        if (idx !== -1) {
+            room.players.splice(idx, 1);
+            io.to(roomId).emit('player_left', room.players);
+            io.to(roomId).emit('player_joined', room.players);
+        }
+    } else {
+        // Kick human
+        const idx = room.players.indexOf(targetPlayer);
+        if (idx !== -1) {
+            room.players.splice(idx, 1);
+            // Notify the kicked player
+            if (targetPlayer.socketId) {
+                io.to(targetPlayer.socketId).emit('kicked');
+                // Force disconnect logic
+                const socketToKick = io.sockets.sockets.get(targetPlayer.socketId);
+                if (socketToKick) {
+                    socketToKick.leave(roomId);
+                }
+            }
+            io.to(roomId).emit('player_left', room.players);
+            io.to(roomId).emit('player_joined', room.players);
+        }
+    }
+  });
+
+  socket.on('get_public_rooms', () => {
+    const publicRooms = getPublicRooms();
+    socket.emit('public_rooms_list', publicRooms);
+  });
+
+  const getPublicRooms = () => {
+    return Object.values(rooms)
+        .filter(r => r.isPublic && r.gameState === null && r.players.length < 4)
+        .map(r => ({
+            id: r.id,
+            playerCount: r.players.length,
+            hostName: r.players.find(p => p.id === r.hostId)?.name || 'Unknown'
+        }));
+  };
 
   const handleBotBid = (roomId: string) => {
       const room = rooms[roomId];
@@ -625,6 +762,15 @@ io.on('connection', (socket: Socket) => {
                 emitToRoom(roomId, 'game_state_update', room.gameState);
             }
 
+            // Transfer host immediately if host disconnected
+            if (room.hostId === player.id) {
+                const nextHost = room.players.find(p => !p.isBot && p.connected);
+                if (nextHost) {
+                    room.hostId = nextHost.id;
+                    io.to(roomId).emit('room_update', { hostId: room.hostId, isPublic: room.isPublic });
+                }
+            }
+
             const timer = setTimeout(() => {
                 const currentRoom = rooms[roomId];
                 if (!currentRoom) return; // Room might be gone
@@ -636,8 +782,19 @@ io.on('connection', (socket: Socket) => {
                     if (idx !== -1) {
                         currentRoom.players.splice(idx, 1);
                         io.to(roomId).emit('player_left', currentRoom.players);
+
+                        // Check empty room
                         if (currentRoom.players.length === 0) {
                             delete rooms[roomId];
+                        } else {
+                            // Transfer host again if needed (e.g. if the "acting host" also timed out)
+                            if (currentRoom.hostId === player.id) {
+                                const nextHost = currentRoom.players.find(pl => !pl.isBot && pl.connected);
+                                if (nextHost) {
+                                    currentRoom.hostId = nextHost.id;
+                                    io.to(roomId).emit('room_update', { hostId: currentRoom.hostId, isPublic: currentRoom.isPublic });
+                                }
+                            }
                         }
                     }
                 }

--- a/src/components/MultiplayerSetup.tsx
+++ b/src/components/MultiplayerSetup.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useGame } from '../context/GameContext';
 import { getStoredPlayerName } from '../utils/storage';
 
 export const MultiplayerSetup: React.FC<{ onBack: () => void }> = ({ onBack }) => {
-  const { joinGame, createGame } = useGame();
+  const { joinGame, createGame, publicRooms, refreshPublicRooms } = useGame();
   const [name, setName] = useState(() => getStoredPlayerName() || '');
   const [roomId, setRoomId] = useState('');
 
@@ -15,8 +15,12 @@ export const MultiplayerSetup: React.FC<{ onBack: () => void }> = ({ onBack }) =
     if (name) createGame(name);
   };
 
+  useEffect(() => {
+    refreshPublicRooms();
+  }, []);
+
   return (
-    <div className="game-container main-menu">
+    <div className="game-container main-menu" style={{overflowY: 'auto', maxHeight: '100vh'}}>
       <h1 className="menu-title">SPIELEN</h1>
       <div className="settings-box">
         <div className="settings-grid">
@@ -29,6 +33,62 @@ export const MultiplayerSetup: React.FC<{ onBack: () => void }> = ({ onBack }) =
                 <input placeholder="Raum ID" value={roomId} onChange={e => setRoomId(e.target.value)} style={{backgroundColor: 'white', color: 'black', padding:'10px', fontSize:'18px', borderRadius:'8px', border:'none', width:'120px'}}/>
                 <button className="menu-button" onClick={handleJoin}>Beitreten</button>
             </div>
+
+            {/* Public Rooms Section */}
+            <div style={{marginTop: '30px', borderTop: '1px solid #555', paddingTop: '20px', width: '100%'}}>
+                <h3 style={{marginBottom: '10px', display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
+                    Öffentliche Räume
+                    <button
+                        onClick={refreshPublicRooms}
+                        style={{
+                            background: 'transparent',
+                            border: '1px solid #aaa',
+                            color: '#aaa',
+                            borderRadius: '4px',
+                            cursor: 'pointer',
+                            fontSize: '0.8em',
+                            padding: '4px 8px'
+                        }}
+                    >
+                        ↻
+                    </button>
+                </h3>
+
+                {publicRooms.length === 0 ? (
+                    <div style={{color: '#888', fontStyle: 'italic'}}>Keine öffentlichen Räume gefunden.</div>
+                ) : (
+                    <div style={{display: 'flex', flexDirection: 'column', gap: '10px', maxHeight: '200px', overflowY: 'auto'}}>
+                        {publicRooms.map(room => (
+                            <div
+                                key={room.id}
+                                onClick={() => {
+                                    setRoomId(room.id);
+                                    // Optional: Auto join if needed, but manual join is safer to confirm name
+                                }}
+                                style={{
+                                    background: '#333',
+                                    padding: '10px',
+                                    borderRadius: '8px',
+                                    cursor: 'pointer',
+                                    display: 'flex',
+                                    justifyContent: 'space-between',
+                                    alignItems: 'center',
+                                    border: roomId === room.id ? '2px solid #4caf50' : '1px solid #444'
+                                }}
+                            >
+                                <div>
+                                    <span style={{fontWeight: 'bold', color: '#ffeb3b'}}>{room.id}</span>
+                                    <span style={{marginLeft: '10px', color: '#ccc'}}>Host: {room.hostName}</span>
+                                </div>
+                                <div style={{color: room.playerCount >= 4 ? '#ff6b6b' : '#4caf50'}}>
+                                    {room.playerCount}/4
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+
             <button className="menu-button" onClick={onBack} style={{marginTop:'20px', background:'#555'}}>Zurück</button>
         </div>
       </div>

--- a/src/components/WaitingRoom.tsx
+++ b/src/components/WaitingRoom.tsx
@@ -3,33 +3,70 @@ import { useGame } from '../context/GameContext';
 import './WaitingRoom.css';
 
 export const WaitingRoom: React.FC = () => {
-  const { state, roomId, startGameMultiplayer, addBotMultiplayer, goToMainMenu, playerId } = useGame();
+  const { state, roomId, hostId, isPublic, startGameMultiplayer, addBotMultiplayer, togglePublic, kickPlayer, goToMainMenu, playerId } = useGame();
   
+  const isHost = playerId === hostId;
+
   return (
     <div className="game-container main-menu">
       <h1 className="menu-title">WARTERAUM</h1>
       <h2 className="room-id-header">Raum ID: <span className="room-id-value">{roomId}</span></h2>
+      <div className="room-status-indicator" style={{textAlign: 'center', marginBottom: '10px', color: isPublic ? '#4caf50' : '#ff9800'}}>
+          {isPublic ? 'Öffentlich' : 'Privat'}
+      </div>
       
       <div className="settings-box waiting-room-box">
         <div className="player-list-header">
             <h3>Spieler ({state.players.length}/4):</h3>
-            {state.players.length < 4 && (
+            {isHost && state.players.length < 4 && (
                 <button className="menu-button small add-bot-btn" onClick={addBotMultiplayer}>+ Bot</button>
             )}
         </div>
         <ul className="player-list">
             {state.players.map((p, idx) => (
-                <li key={idx} className={`player-item ${p.id === playerId ? 'current-player' : ''}`}>
-                    {p.name} {p.id === playerId && '(Du)'} {p.isBot && '(Bot)'}
-                    {p.connected === false && <span style={{color: '#ff6b6b', marginLeft: '8px', fontSize: '0.9em'}}>(Getrennt)</span>}
+                <li key={idx} className={`player-item ${p.id === playerId ? 'current-player' : ''}`} style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
+                    <span>
+                        {p.name} {p.id === playerId && '(Du)'} {p.isBot && '(Bot)'} {p.id === hostId && '👑'}
+                        {p.connected === false && <span style={{color: '#ff6b6b', marginLeft: '8px', fontSize: '0.9em'}}>(Getrennt)</span>}
+                    </span>
+                    {isHost && p.id !== playerId && (
+                        <button
+                            className="kick-button"
+                            onClick={() => kickPlayer(p.id)}
+                            style={{
+                                background: '#ff4444',
+                                border: 'none',
+                                borderRadius: '4px',
+                                color: 'white',
+                                cursor: 'pointer',
+                                padding: '2px 6px',
+                                marginLeft: '10px',
+                                fontSize: '0.8em'
+                            }}
+                            title="Entfernen"
+                        >
+                            ✕
+                        </button>
+                    )}
                 </li>
             ))}
         </ul>
         
         <div className="menu-content waiting-room-actions">
-            <button className="menu-button" onClick={startGameMultiplayer}>Spiel Starten</button>
-            {state.players.length < 4 && (
-                <div className="bot-info-text">Fehlende Spieler werden beim Start durch Bots ersetzt.</div>
+            {isHost ? (
+                <>
+                    <button className="menu-button" onClick={startGameMultiplayer}>Spiel Starten</button>
+                    <button className="menu-button" onClick={togglePublic} style={{fontSize: '0.9em', padding: '8px'}}>
+                        {isPublic ? 'Privat machen' : 'Öffentlich machen'}
+                    </button>
+                    {state.players.length < 4 && (
+                        <div className="bot-info-text">Fehlende Spieler werden beim Start durch Bots ersetzt.</div>
+                    )}
+                </>
+            ) : (
+                <div className="waiting-message" style={{textAlign: 'center', margin: '10px 0', fontStyle: 'italic', color: '#ccc'}}>
+                    Warte auf Host...
+                </div>
             )}
             <button className="menu-button leave-room-btn" onClick={goToMainMenu}>Verlassen</button>
         </div>

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -5,10 +5,19 @@ import { getStoredPlayerId, getStoredRoomId, setStoredRoomId, getStoredPlayerNam
 
 const socket: Socket = io({ autoConnect: false });
 
+export interface PublicRoom {
+    id: string;
+    playerCount: number;
+    hostName: string;
+}
+
 interface GameContextType {
   state: GameState;
   settings: GameSettings;
   roomId: string | null;
+  hostId: string | null;
+  isPublic: boolean;
+  publicRooms: PublicRoom[];
   playCard: (playerId: string, card: Card) => void;
   submitBid: (playerId: string, bid: string) => void;
   announceReKontra: (playerId: string, type: 'Re' | 'Kontra') => void;
@@ -22,6 +31,9 @@ interface GameContextType {
   createGame: (playerName: string) => void;
   startGameMultiplayer: () => void;
   addBotMultiplayer: () => void;
+  togglePublic: () => void;
+  kickPlayer: (targetId: string) => void;
+  refreshPublicRooms: () => void;
   playerId: string | null;
 }
 
@@ -59,6 +71,9 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [settings, setSettings] = useState<GameSettings>(defaultSettings);
   const [state, setState] = useState<GameState>(initialGameState);
   const [roomId, setRoomId] = useState<string | null>(null);
+  const [hostId, setHostId] = useState<string | null>(null);
+  const [isPublic, setIsPublic] = useState<boolean>(false);
+  const [publicRooms, setPublicRooms] = useState<PublicRoom[]>([]);
   const [playerId] = useState<string>(() => getStoredPlayerId());
 
   useEffect(() => {
@@ -75,22 +90,43 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
       });
     }
 
-    socket.on('room_created', ({ roomId, players, settings }: { roomId: string, players: any[], settings: GameSettings }) => {
+    socket.on('room_created', ({ roomId, players, settings, hostId, isPublic }: { roomId: string, players: any[], settings: GameSettings, hostId: string, isPublic: boolean }) => {
       setRoomId(roomId);
       setStoredRoomId(roomId);
       setSettings(settings);
+      setHostId(hostId);
+      setIsPublic(isPublic);
       setState(prev => ({ ...prev, phase: 'Lobby', players: players.map(p => ({ ...p, isBot: p.isBot || false, hand: [], tricks: [], points: 0, team: 'Unknown' })) }));
     });
 
-    socket.on('joined_room', ({ roomId, players, settings }: { roomId: string, players: any[], settings: GameSettings }) => {
+    socket.on('joined_room', ({ roomId, players, settings, hostId, isPublic }: { roomId: string, players: any[], settings: GameSettings, hostId: string, isPublic: boolean }) => {
       setRoomId(roomId);
       setStoredRoomId(roomId);
       setSettings(settings);
+      setHostId(hostId);
+      setIsPublic(isPublic);
       setState(prev => ({ ...prev, phase: 'Lobby', players: players.map(p => ({ ...p, isBot: p.isBot || false, hand: [], tricks: [], points: 0, team: 'Unknown' })) }));
     });
 
     socket.on('player_joined', (players: any[]) => {
       setState(prev => ({ ...prev, players: players.map(p => ({ ...p, isBot: p.isBot || false, hand: [], tricks: [], points: 0, team: 'Unknown' })) }));
+    });
+
+    socket.on('room_update', (data: { hostId?: string, isPublic?: boolean }) => {
+        if (data.hostId) setHostId(data.hostId);
+        if (data.isPublic !== undefined) setIsPublic(data.isPublic);
+    });
+
+    socket.on('kicked', () => {
+        alert('Du wurdest aus dem Raum entfernt.');
+        setRoomId(null);
+        setStoredRoomId(null);
+        setHostId(null);
+        setState(prev => ({ ...initialGameState, phase: 'MainMenu' }));
+    });
+
+    socket.on('public_rooms_list', (rooms: PublicRoom[]) => {
+        setPublicRooms(rooms);
     });
 
     socket.on('game_started', (gameState: GameState) => {
@@ -112,6 +148,9 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
       socket.off('room_created');
       socket.off('joined_room');
       socket.off('player_joined');
+      socket.off('room_update');
+      socket.off('kicked');
+      socket.off('public_rooms_list');
       socket.off('game_started');
       socket.off('game_state_update');
       socket.off('error');
@@ -157,16 +196,13 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
         socket.emit('leave_room', { roomId });
         setStoredRoomId(null);
         setRoomId(null);
+        setHostId(null);
     }
     setState(prev => ({ ...prev, phase: 'MainMenu', lastActivePhase: prev.phase as any }));
   }, [roomId]);
 
   const openSettings = useCallback(() => {
     // Settings are now mostly for game rules which are set on server side by default.
-    // We can keep this empty or remove it. Keeping it to satisfy interface for now, or just setting phase if we kept a view.
-    // But since we removed SettingsScreen, maybe we don't need this.
-    // However, MainMenu.tsx still had openSettings destructured (before I removed it).
-    // Let's just do nothing or maybe log.
   }, []);
 
   const closeSettings = useCallback(() => {
@@ -193,8 +229,45 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
       if (roomId) socket.emit('add_bot', roomId);
   };
 
+  const togglePublic = useCallback(() => {
+      if (roomId) socket.emit('toggle_public', { roomId });
+  }, [roomId]);
+
+  const kickPlayer = useCallback((targetId: string) => {
+      if (roomId) socket.emit('kick_player', { roomId, targetId });
+  }, [roomId]);
+
+  const refreshPublicRooms = useCallback(() => {
+      if (!socket.connected) socket.connect();
+      socket.emit('get_public_rooms');
+  }, []);
+
   return (
-    <GameContext.Provider value={{ state, settings, roomId, playerId, playCard, submitBid, announceReKontra, startNewGame, resumeGame, goToMainMenu, setSettings, openSettings, closeSettings, joinGame, createGame, startGameMultiplayer, addBotMultiplayer }}>
+    <GameContext.Provider value={{
+        state,
+        settings,
+        roomId,
+        hostId,
+        isPublic,
+        publicRooms,
+        playerId,
+        playCard,
+        submitBid,
+        announceReKontra,
+        startNewGame,
+        resumeGame,
+        goToMainMenu,
+        setSettings,
+        openSettings,
+        closeSettings,
+        joinGame,
+        createGame,
+        startGameMultiplayer,
+        addBotMultiplayer,
+        togglePublic,
+        kickPlayer,
+        refreshPublicRooms
+    }}>
       {children}
     </GameContext.Provider>
   );


### PR DESCRIPTION
Implemented the ability for hosts to toggle their lobby between "Public" and "Private". Public lobbies are listed in the multiplayer setup screen for other players to join. Additionally, hosts can now kick players or bots from the lobby.

Changes:
- Backend:
  - Added `isPublic` flag to `GameState`.
  - Implemented `toggle_public` socket event.
  - Implemented `get_public_rooms` to fetch valid lobbies.
  - Implemented `kick_player` to remove specific sockets or bot indices.
  - Added security checks for host-only actions.
- Frontend:
  - Updated `WaitingRoom.tsx` to display Public/Private status and toggle button.
  - Added "Kick" (X) button for hosts next to player names.
  - Updated `MultiplayerSetup.tsx` to fetch and display public rooms.
  - Updated `GameContext` to handle new socket events.

---
*PR created automatically by Jules for task [4234429902555021169](https://jules.google.com/task/4234429902555021169) started by @MokkaMS*