### PR TITLE
Fix host desynchronization on socket reconnection

### DIFF
--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -90,6 +90,21 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
       });
     }
 
+    const handleConnect = () => {
+      const rid = getStoredRoomId();
+      const pname = getStoredPlayerName();
+      if (rid && playerId) {
+        console.log('Reconnecting to room:', rid);
+        socket.emit('join_room', {
+          roomId: rid,
+          playerName: pname || 'Player',
+          playerId
+        });
+      }
+    };
+
+    socket.on('connect', handleConnect);
+
     socket.on('room_created', ({ roomId, players, settings, hostId, isPublic }: { roomId: string, players: any[], settings: GameSettings, hostId: string, isPublic: boolean }) => {
       setRoomId(roomId);
       setStoredRoomId(roomId);
@@ -154,6 +169,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
       socket.off('game_started');
       socket.off('game_state_update');
       socket.off('error');
+      socket.off('connect', handleConnect);
       socket.disconnect();
     };
   }, [playerId]);


### PR DESCRIPTION
Fixes a critical issue where the host would lose control of the game and become desynchronized after a temporary disconnection. Added automatic room re-join logic on socket reconnection to ensure the server updates the player's socket ID and sends the latest game state.Verified with a reproduction script simulating the network drop and reconnect scenario.

---
*PR created automatically by Jules for task [15898166010425661425](https://jules.google.com/task/15898166010425661425) started by @MokkaMS*