### PR TITLE
Unified Card Stacking Animation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -87,70 +87,67 @@ body { margin: 0; padding: 0; background-color: #0d4d1a; color: white; font-fami
 
 /* Trick Cards on Table */
 .trick { width: 100%; height: 100%; position: relative; pointer-events: none; }
-.trick-card-wrapper { position: absolute; display: flex; flex-direction: column; align-items: center; gap: 5px; z-index: 20; transition: all 1.5s ease-in-out; }
-.trick-card { width: 85px; height: 125px; transform: none !important; box-shadow: 0 4px 15px rgba(0,0,0,0.5); }
-.trick-card .card-center { font-size: 32px; }
-.trick-card .card-corner { font-size: 15px; }
-
-.tcc-0 { bottom: 140px; left: 50%; transform: translateX(-50%); animation: p0In 0.4s ease-out; }
-.tcc-1 { left: 160px; top: 50%; transform: translateY(-50%); animation: p1In 0.4s ease-out; }
-.tcc-2 { top: 140px; left: 50%; transform: translateX(-50%); animation: p2In 0.4s ease-out; }
-.tcc-3 { right: 160px; top: 50%; transform: translateY(-50%); animation: p3In 0.4s ease-out; }
-
-/* Animation to Center (Pile) */
-.tcc-0.move-to-center {
-  bottom: 50%;
-  transform: translate(-50%, 50%);
-}
-
-.tcc-1.move-to-center {
+.trick-card-wrapper {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  z-index: 20;
+  transition: all 1.0s ease-in-out;
+  /* Unified positioning base: Center of table */
+  top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
 }
 
-.tcc-2.move-to-center {
-  top: 50%;
-  transform: translate(-50%, -50%);
+.trick-card { width: 85px; height: 125px; transform: none !important; box-shadow: 0 4px 15px rgba(0,0,0,0.5); }
+.trick-card .card-center { font-size: 32px; }
+.trick-card .card-corner { font-size: 15px; }
+
+/* Initial Positions (relative to center) */
+.tcc-0 { transform: translate(-50%, calc(-50% + 135px)); animation: p0In 0.4s ease-out; }
+.tcc-1 { transform: translate(calc(-50% - 265px), -50%); animation: p1In 0.4s ease-out; }
+.tcc-2 { transform: translate(-50%, calc(-50% - 135px)); animation: p2In 0.4s ease-out; }
+.tcc-3 { transform: translate(calc(-50% + 265px), -50%); animation: p3In 0.4s ease-out; }
+
+/* Animation to Center (Pile) */
+.move-to-center {
+  transform: translate(-50%, -50%) !important;
 }
 
-.tcc-3.move-to-center {
-  right: 50%;
-  transform: translate(50%, -50%);
+/* Hide labels during animation */
+.move-to-center .trick-card-label,
+[class*="move-to-player"] .trick-card-label {
+  opacity: 0;
+  transition: opacity 0.3s;
 }
 
 /* Animation to Winner */
 .move-to-player-0 {
-  bottom: 20px !important;
-  left: 50% !important;
-  transform: translateX(-50%) scale(0.5) !important;
+  transform: translate(-50%, calc(-50% + 255px)) scale(0.5) !important;
   opacity: 0;
 }
 
 .move-to-player-1 {
-  left: -60px !important;
-  top: 50% !important;
-  transform: translateY(-50%) scale(0.5) !important;
+  transform: translate(calc(-50% - 485px), -50%) scale(0.5) !important;
   opacity: 0;
 }
 
 .move-to-player-2 {
-  top: 20px !important;
-  left: 50% !important;
-  transform: translateX(-50%) scale(0.5) !important;
+  transform: translate(-50%, calc(-50% - 255px)) scale(0.5) !important;
   opacity: 0;
 }
 
 .move-to-player-3 {
-  right: -60px !important;
-  top: 50% !important;
-  transform: translateY(-50%) scale(0.5) !important;
+  transform: translate(calc(-50% + 485px), -50%) scale(0.5) !important;
   opacity: 0;
 }
 
-@keyframes p0In { from { transform: translate(-50%, 200px); opacity: 0; } }
-@keyframes p1In { from { transform: translate(-200px, -50%); opacity: 0; } }
-@keyframes p2In { from { transform: translate(-50%, -200px); opacity: 0; } }
-@keyframes p3In { from { transform: translate(200px, -50%); opacity: 0; } }
+@keyframes p0In { from { transform: translate(-50%, calc(-50% + 300px)); opacity: 0; } }
+@keyframes p1In { from { transform: translate(calc(-50% - 400px), -50%); opacity: 0; } }
+@keyframes p2In { from { transform: translate(-50%, calc(-50% - 300px)); opacity: 0; } }
+@keyframes p3In { from { transform: translate(calc(-50% + 400px), -50%); opacity: 0; } }
 
 .trick-card-label { font-size: 13px; font-weight: bold; background: rgba(0,0,0,0.8); padding: 2px 8px; border-radius: 4px; }
 

--- a/src/components/GameTable.tsx
+++ b/src/components/GameTable.tsx
@@ -35,14 +35,14 @@ export const GameTable: React.FC = () => {
 
     if (state.currentTrick.length === 4) {
       setTrickAnimationPhase('waiting');
-      // Step 1: Wait 1s (cards on table)
+      // Step 1: Wait 800ms (cards on table)
       timer1 = setTimeout(() => {
         setTrickAnimationPhase('center');
-        // Step 2: Move to center (wait 1s total: 0.5s transition + 0.5s pause)
+        // Step 2: Move to center (wait 1.2s total: 1.0s transition + 0.2s pause)
         timer2 = setTimeout(() => {
           setTrickAnimationPhase('winner');
-        }, 1000);
-      }, 1000);
+        }, 1200);
+      }, 800);
     } else {
       setTrickAnimationPhase('idle');
     }
@@ -231,7 +231,7 @@ export const GameTable: React.FC = () => {
                }
 
                return (
-                 <div key={card.id} className={`trick-card-wrapper tcc-${relativeIdx} ${animationClass}`}>
+                 <div key={card.id} className={`trick-card-wrapper tcc-${relativeIdx} ${animationClass}`} style={{ zIndex: i }}>
                    <div className="trick-card-label">{state.players[playerIdx].name}</div>
                    <CardComponent card={card} className="trick-card" />
                  </div>


### PR DESCRIPTION
This change refactors the end-of-trick card animation to meet the requirement that cards must form a single, perfectly aligned stack in the center of the table before moving to the winner.

Key changes:
1.  **CSS Refactoring**: Replaced mixed `top/bottom/left/right` positioning for trick cards with a unified system centered at `50%/50%`. Initial positions are now set via `transform`.
2.  **Stacking Logic**: The `move-to-center` class now forces all cards to `translate(-50%, -50%)`, creating a perfect stack.
3.  **Linear Movement**: By sharing the same origin and target transform logic, all cards move together as a single unit to the winner.
4.  **Z-Index**: Cards are assigned `z-index` based on their index in the trick, ensuring the last played card is on top.
5.  **Timing Adjustments**: The CSS transition duration was reduced to 1.0s, and the JavaScript wait timer for the 'center' phase was increased to 1.2s. This guarantees that the transition to the center completes fully before the move to the winner begins.
6.  **Visual Cleanup**: Card labels are hidden during the animation.

---
*PR created automatically by Jules for task [6305534868342123837](https://jules.google.com/task/6305534868342123837) started by @MokkaMS*