### PR TITLE
Fix Weiterspielen button and add Reconnect feature

### DIFF
--- a/src/components/GameTable.tsx
+++ b/src/components/GameTable.tsx
@@ -5,7 +5,7 @@ import { sortCards } from '../logic/cardUtils';
 import { CardComponent } from './CardComponent';
 
 export const GameTable: React.FC = () => {
-  const { state, playCard, submitBid, announceReKontra, settings, goToMainMenu, playerId, startNewGame } = useGame();
+  const { state, playCard, submitBid, announceReKontra, settings, goToMainMenu, playerId, startNewGame, reconnect } = useGame();
   const [showFarbenSoloSelection, setShowFarbenSoloSelection] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
   const processingRef = useRef(false);
@@ -254,6 +254,7 @@ export const GameTable: React.FC = () => {
 
         <div className="controls">
           <button onClick={goToMainMenu}>Hauptmenü</button>
+          <button onClick={reconnect} style={{ marginLeft: '10px', backgroundColor: '#555' }}>Reconnect</button>
         </div>
 
         {state.phase === 'Scoring' && state.lastGameResult && (

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -23,6 +23,7 @@ interface GameContextType {
   announceReKontra: (playerId: string, type: 'Re' | 'Kontra') => void;
   startNewGame: () => void;
   resumeGame: () => void;
+  reconnect: () => void;
   goToMainMenu: () => void;
   setSettings: (settings: GameSettings) => void;
   openSettings: () => void;
@@ -75,6 +76,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [isPublic, setIsPublic] = useState<boolean>(false);
   const [publicRooms, setPublicRooms] = useState<PublicRoom[]>([]);
   const [playerId] = useState<string>(() => getStoredPlayerId());
+  const [lastRoomId, setLastRoomId] = useState<string | null>(null);
 
   useEffect(() => {
     socket.connect();
@@ -199,16 +201,23 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
   
   const resumeGame = useCallback(() => {
-    const storedRoomId = getStoredRoomId();
-    if (storedRoomId && playerId) {
+    const roomIdToUse = getStoredRoomId() || lastRoomId;
+    if (roomIdToUse && playerId) {
         // Attempt reconnection
         if (!socket.connected) socket.connect();
-        socket.emit('join_room', { roomId: storedRoomId, playerName: 'Resuming Player', playerId });
+        socket.emit('join_room', { roomId: roomIdToUse, playerName: 'Resuming Player', playerId });
+        setStoredRoomId(roomIdToUse);
     }
-  }, [playerId]);
+  }, [playerId, lastRoomId]);
+
+  const reconnect = useCallback(() => {
+      socket.disconnect();
+      socket.connect();
+  }, []);
 
   const goToMainMenu = useCallback(() => {
     if (roomId) {
+        setLastRoomId(roomId);
         socket.emit('leave_room', { roomId });
         setStoredRoomId(null);
         setRoomId(null);
@@ -272,6 +281,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
         announceReKontra,
         startNewGame,
         resumeGame,
+        reconnect,
         goToMainMenu,
         setSettings,
         openSettings,


### PR DESCRIPTION
This PR addresses two issues:
1.  The "Weiterspielen" button in the Main Menu was not working because the room ID was cleared upon leaving the game. I implemented `lastRoomId` state in `GameContext` to persist the ID temporarily, enabling the resume functionality.
2.  A "Reconnect" button was requested to help users sync back to the game if they experience connection issues. I added this button to the GameTable controls, which triggers a socket disconnect/connect cycle to force a fresh state update from the server.

---
*PR created automatically by Jules for task [17087482989406250919](https://jules.google.com/task/17087482989406250919) started by @MokkaMS*