### PR TITLE
Fix TS build error in server

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -899,7 +899,6 @@ io.on('connection', (socket: Socket) => {
             }, DISCONNECT_TIMEOUT_MS);
 
             disconnectTimeouts.set(player.id, timer);
-            break;
         }
     }
   });


### PR DESCRIPTION
Removed an invalid `break;` statement in `server/src/index.ts` line 902 that was inside a `setTimeout` callback but not inside a loop, causing `tsc` to fail with "Jump target cannot cross function boundary" (TS1107).

---
*PR created automatically by Jules for task [8050297698578846637](https://jules.google.com/task/8050297698578846637) started by @MokkaMS*