### PR TITLE
🧪 test: implement unit tests for storage utility helpers

### DIFF
--- a/src/utils/__tests__/storage.test.ts
+++ b/src/utils/__tests__/storage.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getStoredPlayerId,
+  getStoredRoomId,
+  setStoredRoomId,
+  getStoredPlayerName,
+  setStoredPlayerName,
+} from '../storage';
+
+const STORAGE_KEY = 'doppelkopf_player_id';
+const ROOM_ID_KEY = 'doppelkopf_room_id';
+const PLAYER_NAME_KEY = 'doppelkopf_player_name';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value.toString();
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: localStorageMock,
+});
+
+describe('storage utils', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  describe('getStoredPlayerId', () => {
+    it('should return an existing player ID from localStorage', () => {
+      const existingId = 'existing-id-123';
+      localStorage.setItem(STORAGE_KEY, existingId);
+
+      const result = getStoredPlayerId();
+      expect(result).toBe(existingId);
+      expect(localStorage.getItem(STORAGE_KEY)).toBe(existingId);
+    });
+
+    it('should generate and store a new UUID if none exists and crypto.randomUUID is available', () => {
+      const mockUUID = 'mock-uuid-456';
+
+      // Mock crypto.randomUUID
+      const originalCrypto = globalThis.crypto;
+      // @ts-ignore
+      globalThis.crypto = {
+        ...originalCrypto,
+        randomUUID: vi.fn().mockReturnValue(mockUUID),
+      };
+
+      const result = getStoredPlayerId();
+
+      expect(result).toBe(mockUUID);
+      expect(localStorage.getItem(STORAGE_KEY)).toBe(mockUUID);
+      expect(globalThis.crypto.randomUUID).toHaveBeenCalled();
+
+      // Restore
+      globalThis.crypto = originalCrypto;
+    });
+
+    it('should generate and store a fallback ID if crypto.randomUUID is not available', () => {
+       // Mock crypto to be undefined or missing randomUUID
+       const originalCrypto = globalThis.crypto;
+       // @ts-ignore
+       delete globalThis.crypto;
+
+       const result = getStoredPlayerId();
+
+       expect(result).toBeDefined();
+       expect(typeof result).toBe('string');
+       expect(result.length).toBeGreaterThan(10);
+       expect(localStorage.getItem(STORAGE_KEY)).toBe(result);
+
+       // Restore
+       globalThis.crypto = originalCrypto;
+    });
+  });
+
+  describe('getStoredRoomId and setStoredRoomId', () => {
+    it('should return null if no room ID is stored', () => {
+      expect(getStoredRoomId()).toBeNull();
+    });
+
+    it('should store and retrieve a room ID', () => {
+      const roomId = 'room-abc';
+      setStoredRoomId(roomId);
+      expect(getStoredRoomId()).toBe(roomId);
+      expect(localStorage.getItem(ROOM_ID_KEY)).toBe(roomId);
+    });
+
+    it('should remove the room ID when setting to null', () => {
+      localStorage.setItem(ROOM_ID_KEY, 'some-room');
+      setStoredRoomId(null);
+      expect(getStoredRoomId()).toBeNull();
+      expect(localStorage.getItem(ROOM_ID_KEY)).toBeNull();
+    });
+  });
+
+  describe('getStoredPlayerName and setStoredPlayerName', () => {
+    it('should return null if no player name is stored', () => {
+      expect(getStoredPlayerName()).toBeNull();
+    });
+
+    it('should store and retrieve a player name', () => {
+      const playerName = 'Alice';
+      setStoredPlayerName(playerName);
+      expect(getStoredPlayerName()).toBe(playerName);
+      expect(localStorage.getItem(PLAYER_NAME_KEY)).toBe(playerName);
+    });
+
+    it('should remove the player name when setting to empty string', () => {
+      localStorage.setItem(PLAYER_NAME_KEY, 'Bob');
+      // @ts-ignore - testing with empty string which triggers removal in code
+      setStoredPlayerName('');
+      expect(getStoredPlayerName()).toBeNull();
+      expect(localStorage.getItem(PLAYER_NAME_KEY)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
### 🧪 [testing improvement description]
Implemented a comprehensive unit test suite for the client-side storage utilities.

#### 🎯 **What:**
The testing gap addressed was the lack of unit tests for the `src/utils/storage.ts` module, which handles critical persistent state like the player's unique ID, last room ID, and player name.

#### 📊 **Coverage:**
The following scenarios are now fully tested:
- **`getStoredPlayerId`**: 
    - Retrieving an existing ID from `localStorage`.
    - Generating a new UUID when `crypto.randomUUID` is available.
    - Generating a fallback alphanumeric ID when `crypto` globals are missing.
    - Ensuring newly generated IDs are correctly persisted.
- **`getStoredRoomId` / `setStoredRoomId`**:
    - Storing, retrieving, and removing room IDs.
- **`getStoredPlayerName` / `setStoredPlayerName`**:
    - Storing, retrieving, and removing player names.

#### ✨ **Result:**
- Increased total frontend test count from 13 to 22.
- Ensured reliability of the player identification logic across different browser environments (with/without modern Crypto API).
- Established a pattern for mocking browser globals (`localStorage`, `crypto`) in the project's Vitest/Bun test environment.

---
*PR created automatically by Jules for task [3474115442153938503](https://jules.google.com/task/3474115442153938503) started by @MokkaMS*