### PR TITLE
⚡ Optimize checkAndRevealRemainingPlayers player count logic

### DIFF
--- a/server/src/logic/GameEngine.benchmark.ts
+++ b/server/src/logic/GameEngine.benchmark.ts
@@ -1,0 +1,40 @@
+import { GameEngine } from './GameEngine';
+import { GameState, Player, Team } from './types';
+
+const createPlayer = (id: string, team: Team, isRevealed: boolean): Player => ({
+    id,
+    name: `Player ${id}`,
+    isBot: false,
+    hand: [],
+    team,
+    isRevealed,
+    points: 0,
+    tournamentPoints: 0,
+    tricks: [],
+});
+
+const state = {
+    rePlayerIds: ['p1', 'p2'],
+    kontraPlayerIds: ['p3', 'p4'],
+    players: [
+        createPlayer('p1', 'Re', true),
+        createPlayer('p2', 'Re', false),
+        createPlayer('p3', 'Kontra', true),
+        createPlayer('p4', 'Kontra', false),
+    ],
+} as unknown as GameState;
+
+const ITERATIONS = 10_000_000;
+
+console.log('Running GameEngine.checkAndRevealRemainingPlayers benchmark...');
+
+const start = performance.now();
+for (let i = 0; i < ITERATIONS; i++) {
+    // Modify state slightly to ensure compiler doesn't optimize away the call completely
+    state.players[1].isRevealed = (i % 2 === 0);
+    GameEngine.checkAndRevealRemainingPlayers(state);
+}
+const end = performance.now();
+
+const duration = end - start;
+console.log(`Time taken for ${ITERATIONS.toLocaleString()} iterations: ${duration.toFixed(2)} ms`);

--- a/server/src/logic/GameEngine.ts
+++ b/server/src/logic/GameEngine.ts
@@ -150,8 +150,19 @@ export class GameEngine {
       return;
     }
 
-    const revealedReCount = state.players.filter(p => p.team === 'Re' && p.isRevealed).length;
-    const revealedKontraCount = state.players.filter(p => p.team === 'Kontra' && p.isRevealed).length;
+    let revealedReCount = 0;
+    let revealedKontraCount = 0;
+
+    for (let i = 0; i < state.players.length; i++) {
+      const p = state.players[i];
+      if (p.isRevealed) {
+        if (p.team === 'Re') {
+          revealedReCount++;
+        } else if (p.team === 'Kontra') {
+          revealedKontraCount++;
+        }
+      }
+    }
 
     if (revealedReCount === 2) {
       // Reveal all Kontra


### PR DESCRIPTION
💡 **What:** Replaced the two separate `state.players.filter(...).length` calls in `GameEngine.checkAndRevealRemainingPlayers` with a single loop that counts both teams simultaneously.

🎯 **Why:** The previous approach iterated over the `state.players` array twice and allocated two new intermediate arrays just to get a count. Although the N is small (typically 4 in Doppelkopf), doing this in a single pass without array allocations is a standard O(N) optimization over O(2N) operations.

📊 **Measured Improvement:** 
A benchmark was created (`GameEngine.benchmark.ts`) running the `checkAndRevealRemainingPlayers` function 10,000,000 times:
- **Baseline (Before):** ~1505 ms
- **Optimized (After):** ~653 ms
- **Change:** ~2.3x faster execution for this specific logic path.

Unit tests (`bun test`) continue to pass completely, confirming no regressions were introduced.

---
*PR created automatically by Jules for task [9058001011172780643](https://jules.google.com/task/9058001011172780643) started by @MokkaMS*