### PR TITLE
🧪 add tests for decideAnnouncement in Bot AI

### DIFF
--- a/server/src/logic/Bot.test.ts
+++ b/server/src/logic/Bot.test.ts
@@ -206,4 +206,145 @@ describe('Bot AI', () => {
         expect(bestCard.suit).toBe(Suit.Pik);
         expect(bestCard.value).toBe(CardValue.Ass);
     });
+
+    describe('decideAnnouncement', () => {
+        const settings: GameSettings = {
+            mitNeunen: false,
+            dullenAlsHoechste: true,
+            fuchsGefangen: true,
+            doppelkopfPunkte: true,
+            karlchen: true,
+            schweinchen: false,
+        };
+
+        const createBaseState = (player: Player): GameState => ({
+            players: [
+                player,
+                { id: 'p2', name: 'P2', hand: [], isBot: true, team: 'Unknown', points: 0, tournamentPoints: 0, tricks: [] } as Player,
+                { id: 'p3', name: 'P3', hand: [], isBot: true, team: 'Unknown', points: 0, tournamentPoints: 0, tricks: [] } as Player,
+                { id: 'p4', name: 'P4', hand: [], isBot: true, team: 'Unknown', points: 0, tournamentPoints: 0, tricks: [] } as Player,
+            ],
+            currentPlayerIndex: 0,
+            dealerIndex: 3,
+            currentTrick: [],
+            trickStarterIndex: 0,
+            trickWinnerIndex: null,
+            gameType: GameType.Normal,
+            trumpSuit: null,
+            rePlayerIds: [],
+            kontraPlayerIds: [],
+            announcements: {},
+            reKontraAnnouncements: {},
+            specialPoints: { re: [], kontra: [] },
+            notifications: [],
+            currentTrickNotifications: [],
+            phase: 'Playing',
+        });
+
+        const createPlayer = (id: string, hand: Card[]): Player => ({
+            id,
+            name: id.toUpperCase(),
+            hand,
+            isBot: true,
+            team: 'Unknown',
+            points: 0,
+            tournamentPoints: 0,
+            tricks: [],
+        });
+
+        test('returns null if already announced', () => {
+            const player = createPlayer('p1', new Array(10).fill({ id: 'c1' } as Card));
+            const state = createBaseState(player);
+            state.reKontraAnnouncements['p1'] = 'Re';
+
+            expect(Bot.decideAnnouncement(player, state, settings)).toBeNull();
+        });
+
+        test('returns null if hand length < 9', () => {
+            const player = createPlayer('p1', new Array(8).fill({ id: 'c1' } as Card));
+            const state = createBaseState(player);
+
+            expect(Bot.decideAnnouncement(player, state, settings)).toBeNull();
+        });
+
+        test('returns Re for strong Re hand', () => {
+            const hand: Card[] = [
+                { id: '1', suit: Suit.Herz, value: CardValue.Zehn }, // High trump
+                { id: '2', suit: Suit.Kreuz, value: CardValue.Dame }, // High trump
+                { id: '3', suit: Suit.Pik, value: CardValue.Dame },   // High trump
+                { id: '4', suit: Suit.Herz, value: CardValue.Bube },  // Trump
+                { id: '5', suit: Suit.Karo, value: CardValue.Ass },   // Trump
+                { id: '6', suit: Suit.Karo, value: CardValue.Zehn },  // Trump
+                { id: '7', suit: Suit.Kreuz, value: CardValue.Ass },  // Fehl
+                { id: '8', suit: Suit.Pik, value: CardValue.Ass },    // Fehl
+                { id: '9', suit: Suit.Herz, value: CardValue.Ass },   // Fehl
+                { id: '10', suit: Suit.Kreuz, value: CardValue.König } // Fehl
+            ];
+            const player = createPlayer('p1', hand);
+            const state = createBaseState(player);
+            state.rePlayerIds = ['p1'];
+
+            expect(Bot.decideAnnouncement(player, state, settings)).toBe('Re');
+        });
+
+        test('returns Kontra for strong Kontra hand', () => {
+            const hand: Card[] = [
+                { id: '1', suit: Suit.Herz, value: CardValue.Zehn }, // High trump
+                { id: '2', suit: Suit.Kreuz, value: CardValue.Dame }, // High trump
+                { id: '3', suit: Suit.Pik, value: CardValue.Dame },   // High trump
+                { id: '4', suit: Suit.Herz, value: CardValue.Bube },  // Trump
+                { id: '5', suit: Suit.Karo, value: CardValue.Ass },   // Trump
+                { id: '6', suit: Suit.Karo, value: CardValue.Zehn },  // Trump
+                { id: '7', suit: Suit.Kreuz, value: CardValue.Ass },  // Fehl
+                { id: '8', suit: Suit.Pik, value: CardValue.Ass },    // Fehl
+                { id: '9', suit: Suit.Herz, value: CardValue.Ass },   // Fehl
+                { id: '10', suit: Suit.Kreuz, value: CardValue.König } // Fehl
+            ];
+            const player = createPlayer('p1', hand);
+            const state = createBaseState(player);
+            state.kontraPlayerIds = ['p1'];
+
+            expect(Bot.decideAnnouncement(player, state, settings)).toBe('Kontra');
+        });
+
+        test('returns Re for Hochzeit player with 2 Kreuz Damen and 5+ trumps', () => {
+            const hand: Card[] = [
+                { id: '1', suit: Suit.Kreuz, value: CardValue.Dame }, // High trump
+                { id: '2', suit: Suit.Kreuz, value: CardValue.Dame }, // High trump
+                { id: '3', suit: Suit.Herz, value: CardValue.Bube },  // Trump
+                { id: '4', suit: Suit.Karo, value: CardValue.Ass },   // Trump
+                { id: '5', suit: Suit.Karo, value: CardValue.Zehn },  // Trump
+                { id: '6', suit: Suit.Kreuz, value: CardValue.Ass },  // Fehl
+                { id: '7', suit: Suit.Pik, value: CardValue.Ass },    // Fehl
+                { id: '8', suit: Suit.Herz, value: CardValue.Ass },   // Fehl
+                { id: '9', suit: Suit.Kreuz, value: CardValue.König },// Fehl
+                { id: '10', suit: Suit.Pik, value: CardValue.König }   // Fehl
+            ];
+            const player = createPlayer('p1', hand);
+            const state = createBaseState(player);
+            // In Hochzeit, the one with both Kreuz Damen is Re.
+
+            expect(Bot.decideAnnouncement(player, state, settings)).toBe('Re');
+        });
+
+        test('returns null for weak hand', () => {
+            const hand: Card[] = [
+                { id: '1', suit: Suit.Karo, value: CardValue.Ass },   // Trump
+                { id: '2', suit: Suit.Karo, value: CardValue.Zehn },  // Trump
+                { id: '3', suit: Suit.Karo, value: CardValue.König }, // Trump
+                { id: '4', suit: Suit.Karo, value: CardValue.Bube },  // Trump
+                { id: '5', suit: Suit.Karo, value: CardValue.Neun },  // Trump
+                { id: '6', suit: Suit.Kreuz, value: CardValue.Ass },  // Fehl
+                { id: '7', suit: Suit.Pik, value: CardValue.Ass },    // Fehl
+                { id: '8', suit: Suit.Herz, value: CardValue.Ass },   // Fehl
+                { id: '9', suit: Suit.Kreuz, value: CardValue.König },// Fehl
+                { id: '10', suit: Suit.Pik, value: CardValue.König }   // Fehl
+            ];
+            const player = createPlayer('p1', hand);
+            const state = createBaseState(player);
+            state.rePlayerIds = ['p1'];
+
+            expect(Bot.decideAnnouncement(player, state, settings)).toBeNull();
+        });
+    });
 });


### PR DESCRIPTION
- Added comprehensive unit tests for `Bot.decideAnnouncement` in `server/src/logic/Bot.test.ts`.
- Covered scenarios: already announced, hand size < 9, strong Re hand, strong Kontra hand, Hochzeit with 2 Kreuz Damen, and weak hands.
- Refactored test mocks for better type safety and consistency.