### PR TITLE
🔒 [security fix] Add input validation for submit_bid

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,7 +7,7 @@ import crypto from 'crypto';
 import { GameEngine } from './logic/GameEngine';
 import { GameState, Card, GameSettings, GameType, Suit, CardValue } from './logic/types';
 import { Bot } from './logic/Bot';
-import { validatePlayerName, validateRoomId, validatePlayerId, isValidOrigin } from './utils/validation';
+import { validatePlayerName, validateRoomId, validatePlayerId, isValidOrigin, validateBid } from './utils/validation';
 import {
   MAX_ROOMS,
   CREATE_ROOM_RATE_LIMIT,
@@ -897,6 +897,12 @@ io.on('connection', (socket: Socket) => {
     const roomIdError = validateRoomId(roomId);
     if (roomIdError) {
       socket.emit('error', roomIdError);
+      return;
+    }
+
+    const bidError = validateBid(bid);
+    if (bidError) {
+      socket.emit('error', bidError);
       return;
     }
 

--- a/server/src/utils/validation.test.ts
+++ b/server/src/utils/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { validatePlayerName, validateRoomId, validatePlayerId, isValidOrigin } from "./validation";
+import { validatePlayerName, validateRoomId, validatePlayerId, isValidOrigin, validateBid } from "./validation";
 
 describe("Validation Utils", () => {
   describe("validatePlayerName", () => {
@@ -67,6 +67,41 @@ describe("Validation Utils", () => {
     it("should reject invalid characters", () => {
       expect(validatePlayerId("player id")).toBe("Player ID contains invalid characters");
       expect(validatePlayerId("player@id")).toBe("Player ID contains invalid characters");
+    });
+  });
+
+  describe("validateBid", () => {
+    it("should allow valid standard bids", () => {
+      expect(validateBid("Gesund")).toBeNull();
+      expect(validateBid("Hochzeit")).toBeNull();
+      expect(validateBid("DamenSolo")).toBeNull();
+      expect(validateBid("BubenSolo")).toBeNull();
+      expect(validateBid("DamenBubensolo")).toBeNull();
+      expect(validateBid("Fleischlos")).toBeNull();
+    });
+
+    it("should allow valid FarbenSolo bids", () => {
+      expect(validateBid("FarbenSolo_Kreuz")).toBeNull();
+      expect(validateBid("FarbenSolo_Pik")).toBeNull();
+      expect(validateBid("FarbenSolo_Herz")).toBeNull();
+      expect(validateBid("FarbenSolo_Karo")).toBeNull();
+    });
+
+    it("should reject invalid bid strings", () => {
+      expect(validateBid("InvalidBid")).toBe("Invalid bid value");
+      expect(validateBid("Solo")).toBe("Invalid bid value");
+    });
+
+    it("should reject malformed FarbenSolo bids", () => {
+      expect(validateBid("FarbenSolo_")).toBe("Invalid bid value");
+      expect(validateBid("FarbenSolo_Invalid")).toBe("Invalid bid value");
+      expect(validateBid("FarbenSolo")).toBe("Invalid bid value");
+    });
+
+    it("should reject empty or non-string bids", () => {
+      // @ts-ignore
+      expect(validateBid(null)).toBe("Bid is required");
+      expect(validateBid("")).toBe("Bid is required");
     });
   });
 

--- a/server/src/utils/validation.ts
+++ b/server/src/utils/validation.ts
@@ -1,3 +1,5 @@
+import { Suit } from '../logic/types';
+
 export const MIN_PLAYER_NAME_LENGTH = 1;
 export const MAX_PLAYER_NAME_LENGTH = 20;
 
@@ -24,6 +26,21 @@ export const validatePlayerId = (playerId: string): string | null => {
   if (playerId.length > 36) return 'Player ID is too long';
   if (!/^[a-zA-Z0-9-]+$/.test(playerId)) return 'Player ID contains invalid characters';
   return null;
+};
+
+export const validateBid = (bid: string): string | null => {
+  if (!bid || typeof bid !== 'string') return 'Bid is required';
+
+  const validBids = ['Gesund', 'Hochzeit', 'DamenSolo', 'BubenSolo', 'DamenBubensolo', 'Fleischlos'];
+  if (validBids.includes(bid)) return null;
+
+  for (const suit of Object.values(Suit)) {
+    if (bid === `FarbenSolo_${suit}`) {
+      return null;
+    }
+  }
+
+  return 'Invalid bid value';
 };
 
 /**


### PR DESCRIPTION
This commit adds strict input validation for the 'bid' parameter in the 'submit_bid' socket event handler. Previously, arbitrary strings were accepted and stored in the game state, which could lead to potential injection or state corruption.

The new 'validateBid' utility ensures that only allowed bid values are accepted, including:
- 'Gesund'
- 'Hochzeit'
- 'DamenSolo'
- 'BubenSolo'
- 'DamenBubensolo'
- 'Fleischlos'
- 'FarbenSolo_[Suit]' (where [Suit] is one of Kreuz, Pik, Herz, Karo)

Unit tests have been added to verify the validation logic and ensure it rejects malformed or unauthorized strings.