### PR TITLE
🔒 [security] Enforce secure randomness for player ID generation

### DIFF
--- a/src/utils/__tests__/storage.test.ts
+++ b/src/utils/__tests__/storage.test.ts
@@ -103,7 +103,7 @@ describe('storage utils', () => {
       });
     });
 
-    it('should generate and store a fallback ID if crypto is not available at all', () => {
+    it('should throw an error if crypto is not available at all', () => {
        // Mock crypto to be undefined
        const originalCrypto = globalThis.crypto;
        Object.defineProperty(globalThis, 'crypto', {
@@ -111,12 +111,7 @@ describe('storage utils', () => {
         configurable: true
        });
 
-       const result = getStoredPlayerId();
-
-       expect(result).toBeDefined();
-       expect(typeof result).toBe('string');
-       expect(result.length).toBeGreaterThan(10);
-       expect(localStorage.getItem(STORAGE_KEY)).toBe(result);
+       expect(() => getStoredPlayerId()).toThrow('Secure Crypto API not available for player ID generation');
 
        // Restore
        Object.defineProperty(globalThis, 'crypto', {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -12,7 +12,7 @@ export const getStoredPlayerId = (): string => {
         .map((b) => b.toString(16).padStart(2, '0'))
         .join('');
     } else {
-      storedId = Date.now().toString() + Math.random().toString();
+      throw new Error('Secure Crypto API not available for player ID generation');
     }
     localStorage.setItem(STORAGE_KEY, storedId);
   }


### PR DESCRIPTION
Removed the insecure fallback in `getStoredPlayerId` that used `Math.random()` and `Date.now()`. The application now requires the Web Crypto API to generate identifiers and throws an error if it is unavailable, ensuring cryptographically secure player IDs. Updated unit tests in `src/utils/__tests__/storage.test.ts` to reflect this change.